### PR TITLE
Fixed proc/haswallitem and structure/sign dir

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -720,7 +720,7 @@ GLOBAL_LIST_INIT(WALLITEMS_INVERSE, typecacheof(list(
 
 
 /proc/gotwallitem(loc, dir, check_external = 0)
-	var/locdir = get_step(loc, dir)
+	var/locdir = get_step(loc, turn(dir,180)) //SinguloStation13 Edit
 	for(var/obj/O in loc)
 		if(is_type_in_typecache(O, GLOB.WALLITEMS) && check_external != 2)
 			//Direction works sometimes

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -193,7 +193,7 @@
 						 "<span class='notice'>You attach the sign to [target_turf].</span>")
 	playsound(target_turf, 'sound/items/deconstruct.ogg', 50, TRUE)
 	placed_sign.obj_integrity = obj_integrity
-	placed_sign.setDir(dir)
+	placed_sign.setDir(turn(dir,180)) //SinguloStation13 Edit (Normally all wallframes's dir point away from the wall, not look into it when placed.)
 	qdel(src)
 
 /obj/structure/sign/nanotrasen


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes a bug i encountered in unsorted.dm in the gotwallitem proc in which due to a wrong dir, a wrong tile was checked for wallmounts instead of the one in question.

Also 180's the structure/sign dir when placed on a wall using plastic to make it more consistent with other wallmounts (dir always looking away from the wall instead of into it) since otherwise would also fuck over with gotwallmount proc in 1 wide hallways.

Before/Afters:
Testing consisted of having 3 wall with 1 wallmount, 1 poster and 1 plastic sign in that order and then trying to place other wallmounts ontop/across it. X marks are failures to place wallmounts whereas a tick mark is a wallmount successfully placed onto it.

Before:
[1](https://i.imgur.com/I2ufSU5.png) | [2](https://i.imgur.com/9y8jgdl.png)
You couldn't place anything across from wallmounts leaving the wall completely blank, but you were able to place wallmounts into posters/signs. stacking normal wallmounts didn't work as intended.

After:
[1](https://i.imgur.com/UYJ7tXe.png) | [2](https://i.imgur.com/AhYNjAn.png)
No longer able to stack any wallmounts on occupied walls while still be able to utilize both walls in the 1 wide corridor

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Being able to utilize wallmounts on both walls in a 1 wide hallway good

## Changelog
:cl:
fix: wallmounts now fit on both sides of a 1-wide corridor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
