### PR TITLE
Adds respawn cooldowns

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -75,6 +75,11 @@
 	integer = FALSE
 	min_val = 1
 
+/datum/config_entry/number/respawncooldown
+	config_entry_value = 90
+	integer = TRUE
+	min_val = 1
+
 /datum/config_entry/number/brother_scaling_coeff	//how many players per brother team
 	config_entry_value = 25
 	integer = FALSE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -3,6 +3,8 @@ GLOBAL_LIST_EMPTY(ghost_images_simple) //this is a list of all ghost images as t
 
 GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 
+GLOBAL_VAR_INIT(respawn_cooldown_number, CONFIG_GET(number/respawncooldown))
+
 /mob/dead/observer
 	name = "ghost"
 	desc = "It's a g-g-g-g-ghooooost!" //jinkies!
@@ -152,7 +154,6 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	grant_all_languages()
 	show_data_huds()
 	data_huds_on = 1
-	COOLDOWN_START(src, respawn_cooldown_timer, respawn_cooldown_count)
 
 
 /mob/dead/observer/get_photo_description(obj/item/camera/camera)
@@ -173,9 +174,8 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 
 /mob/
 	COOLDOWN_DECLARE(respawn_cooldown_timer) //respawn stuff, don't mind me!
-	var/respawn_cooldown_count = 90 MINUTES
 
-/mob/dead/observer/verb/abandon_mob()
+/mob/dead/verb/abandon_mob()
 	set name = "Respawn"
 	set category = "OOC"
 

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -12,3 +12,4 @@
 /mob/proc/death(gibbed)
 	SEND_SIGNAL(src, COMSIG_MOB_DEATH, gibbed)
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_DEATH, src , gibbed)
+	COOLDOWN_START(src, respawn_cooldown_timer, GLOB.respawn_cooldown_number MINUTES)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -688,47 +688,6 @@
 		to_chat(src, "You don't have a mind datum for some reason, so you can't add a note to it.")
 
 /**
-  * Allows you to respawn, abandoning your current mob
-  *
-  * This sends you back to the lobby creating a new dead mob
-  *
-  * Only works if flag/norespawn is allowed in config
-  */
-/mob/verb/abandon_mob()
-	set name = "Respawn"
-	set category = "OOC"
-
-	if (CONFIG_GET(flag/norespawn))
-		return
-	if ((stat != DEAD || !( SSticker )))
-		to_chat(usr, "<span class='boldnotice'>You must be dead to use this!</span>")
-		return
-
-	log_game("[key_name(usr)] used abandon mob.")
-
-	to_chat(usr, "<span class='boldnotice'>Please roleplay correctly!</span>")
-
-	if(!client)
-		log_game("[key_name(usr)] AM failed due to disconnect.")
-		return
-	client.screen.Cut()
-	client.screen += client.void
-	if(!client)
-		log_game("[key_name(usr)] AM failed due to disconnect.")
-		return
-
-	var/mob/dead/new_player/M = new /mob/dead/new_player()
-	if(!client)
-		log_game("[key_name(usr)] AM failed due to disconnect.")
-		qdel(M)
-		return
-
-	M.key = key
-//	M.Login()	//wat
-	return
-
-
-/**
   * Sometimes helps if the user is stuck in another perspective or camera
   */
 /mob/verb/cancel_camera()

--- a/config/config.txt
+++ b/config/config.txt
@@ -207,7 +207,11 @@ VOTE_AUTOTRANSFER_INTERVAL 18000
 # DEFAULT_NO_VOTE
 
 ## disable abandon mob
-NORESPAWN
+## NORESPAWN
+## Commented out due to replacement, kept in for future shitcoding
+
+## lets malt change cooldown time on respawn. This took too long to make.
+# RESPAWNCOOLDOWN
 
 ## disables calling del(src) on newmobs if they logout before spawnin in
 # DONT_DEL_NEWMOB


### PR DESCRIPTION
## About The Pull Request

Adds a cooldown to the respawn verb, allowing ghosts to respawn 90 minutes after their death. The verb's access has been changed to be only accessible by ghosts, as to avoid any... _mishaps._

## Why It's Good For The Game

It allows for people irreversibly killed in-game to return (after a cooldown, to balance it out) in a regular body.
The feature would allow for more option of returning other than using ghost spawners.

## Changelog
:cl:
add: Respawn Cooldowns
code: Moved respawn (abandon_mob()) code to Observer instead of Mob
config: Removed the need of the "norespawn" flag
/:cl: