### PR TITLE
Fixes CL Generator

### DIFF
--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -24,8 +24,8 @@ jobs:
           pip install ruamel.yaml PyGithub
       - name: Make CL
         env:
-          #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} Use this instead if you have unprotected branches
-          GITHUB_TOKEN: ${{ secrets.CHANGELOG_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          #GITHUB_TOKEN: ${{ secrets.CHANGELOG_TOKEN }} Use this instead if you have protected branches. Make a secret named CHANGELOG_TOKEN with a valid access token before enabling this
           GIT_EMAIL: "60119942+WaspStation-Bot@users.noreply.github.com"
           GIT_NAME: "WaspStation-Bot"
         run: python tools/changelog/generate_cl.py


### PR DESCRIPTION
## About The Pull Request
As I believe you don't (yet) have a protected master branch, this'll make your CL generator work again for the time being.

## Why It's Good For The Game
Allows players to get changelog updates ingame again

## Changelog
:cl:
code: Changelog generator should work again
/:cl: