### PR TITLE
Makes pressure proofing check all clothing with coverage

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -54,11 +54,16 @@
 
 
 /mob/living/carbon/human/calculate_affecting_pressure(pressure)
-	if (wear_suit && head && istype(wear_suit, /obj/item/clothing) && istype(head, /obj/item/clothing))
-		var/obj/item/clothing/CS = wear_suit
-		var/obj/item/clothing/CH = head
-		if (CS.clothing_flags & CH.clothing_flags & STOPSPRESSUREDAMAGE)
-			return ONE_ATMOSPHERE
+	var/chest_covered = FALSE
+	var/head_covered = FALSE
+	for(var/obj/item/clothing/C in get_equipped_items())
+		if((C.body_parts_covered & CHEST) && (C.clothing_flags & STOPSPRESSUREDAMAGE))
+			chest_covered = TRUE
+		if((C.body_parts_covered & HEAD) && (C.clothing_flags & STOPSPRESSUREDAMAGE))
+			head_covered = TRUE
+
+	if(chest_covered && head_covered)
+		return ONE_ATMOSPHERE
 	return pressure
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes the pressure-proof check account for other clothes that cover the chest & head that are spaceproof, not just suit slot and head slot (for example xenobio-proofed leather jacket + beanie).

## Why It's Good For The Game

Makes it so xenobiologists can now just use a jumpsuit / any swag suit they want pressure-proofed without having to put on a coat that'd ruin the drip.

## Changelog
:cl:
tweak: You can now wear xenobio pressure-proofed jumpsuits in space.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
