### PR TITLE
Increases the amount of fuel used by the AME per cycle by 20 times

### DIFF
--- a/waspstation/code/modules/power/antimatter/control.dm
+++ b/waspstation/code/modules/power/antimatter/control.dm
@@ -83,7 +83,7 @@
 	var/core_damage = 0
 	var/fuel = fueljar.usefuel(fuel_injection)
 
-	stored_power = (fuel/core_power)*fuel*200000
+	stored_power = (fuel/core_power)*fuel*10000 //Singulo edit - nerfs AME (was 200000)
 	//Now check if the cores could deal with it safely, this is done after so you can overload for more power if needed, still a bad idea
 	if(fuel > (2*core_power))//More fuel has been put in than the current cores can deal with
 		if(prob(50))


### PR DESCRIPTION
## About The Pull Request

Decreases the fuel to energy ratio by 20 times

## Why It's Good For The Game

The AME was brokenly overpowered and could power the station for hours with little to know effort or difficulty, this PR puts it into a more temporary niche.

## Changelog
:cl:
tweak: changes the fuel to energy ratio
/:cl: