### PR TITLE
Plastic flap and holofirelock nerfs

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -282,7 +282,10 @@
 	if(density || operating || welded)
 		return
 	if(world.time >= emergency_close_timer || !consider_timer)
-		close()
+		if(istype(src, /obj/machinery/door/firedoor/window))
+			close()
+		else
+			addtimer(CALLBACK(src, close()), 10)
 
 /obj/machinery/door/firedoor/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -282,10 +282,7 @@
 	if(density || operating || welded)
 		return
 	if(world.time >= emergency_close_timer || !consider_timer)
-		if(istype(src, /obj/machinery/door/firedoor/window))
-			close()
-		else
-			addtimer(CALLBACK(src, close()), 10)
+		close()
 
 /obj/machinery/door/firedoor/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -103,7 +103,7 @@
 /obj/structure/holosign/barrier/atmos/Initialize()
 	. = ..()
 	air_update_turf(TRUE)
-	timerid = QDEL_IN(src, duration) //Singulo edit - Nerfs holofirelocks, plastic flaps, and firedoors
+	timerid = QDEL_IN(src, duration) //Singulo edit - Nerfs holofirelocks and plastic flaps
 
 /obj/structure/holosign/barrier/cyborg
 	name = "Energy Field"

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -99,6 +99,7 @@
 	alpha = 150
 	flags_1 = RAD_PROTECT_CONTENTS_1 | RAD_NO_CONTAMINATE_1
 	rad_insulation = RAD_LIGHT_INSULATION
+	//More vars and some procs in singulostation/code/game/objects/structures/holosign.dm
 
 /obj/structure/holosign/barrier/atmos/Initialize()
 	. = ..()

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -103,6 +103,7 @@
 /obj/structure/holosign/barrier/atmos/Initialize()
 	. = ..()
 	air_update_turf(TRUE)
+	timerid = QDEL_IN(src, duration) //Singulo edit - Nerfs holofirelocks, plastic flaps, and firedoors
 
 /obj/structure/holosign/barrier/cyborg
 	name = "Energy Field"

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -89,8 +89,8 @@
 
 	else if(isliving(A)) // You Shall Not Pass!
 		var/mob/living/M = A
-		if(iscarbon(A)) //Singulo edit - nerfs holofans, plastic flaps, and firedoors
-			. = FALSE //Singulo edit - nerfs holofans, plastic flaps, and firedoors
+		if(iscarbon(A)) //Singulo edit - nerfs holofans and plastic flaps
+			. = FALSE //Singulo edit - nerfs holofans and plastic flaps
 		if(isbot(A)) //Bots understand the secrets
 			return TRUE
 		if(M.buckled && istype(M.buckled, /mob/living/simple_animal/bot/mulebot)) // mulebot passenger gets a free pass.

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -89,7 +89,7 @@
 
 	else if(isliving(A)) // You Shall Not Pass!
 		var/mob/living/M = A
-		if(iscarbon(A)) //Singulo edit - nerfs holofans and plastic flaps
+		if(ishuman(A)) //Singulo edit - nerfs holofans and plastic flaps
 			. = FALSE //Singulo edit - nerfs holofans and plastic flaps
 		if(isbot(A)) //Bots understand the secrets
 			return TRUE

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -89,6 +89,8 @@
 
 	else if(isliving(A)) // You Shall Not Pass!
 		var/mob/living/M = A
+		if(iscarbon(A)) //Singulo edit - nerfs holofans, plastic flaps, and firedoors
+			. = FALSE //Singulo edit - nerfs holofans, plastic flaps, and firedoors
 		if(isbot(A)) //Bots understand the secrets
 			return TRUE
 		if(M.buckled && istype(M.buckled, /mob/living/simple_animal/bot/mulebot)) // mulebot passenger gets a free pass.

--- a/singulostation/code/game/objects/structures/holosign.dm
+++ b/singulostation/code/game/objects/structures/holosign.dm
@@ -1,6 +1,6 @@
 /obj/structure/holosign/barrier/atmos
 	var/timerid
-	var/duration = 60 MINUTES
+	var/duration = 90 MINUTES
 
 /obj/structure/holosign/barrier/atmos/Destroy()
 	. = ..()
@@ -8,4 +8,4 @@
 
 /obj/structure/holosign/barrier/atmos/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>The holofan will decay in [timeleft(timerid)/10] seconds.</span>"
+	. += "<span class='notice'>The holofan will decay in [timeleft(timerid)/600] minutes.</span>"

--- a/singulostation/code/game/objects/structures/holosign.dm
+++ b/singulostation/code/game/objects/structures/holosign.dm
@@ -1,0 +1,11 @@
+/obj/structure/holosign/barrier/atmos
+	var/timerid
+	var/duration = 60 MINUTES
+
+/obj/structure/holosign/barrier/atmos/Destroy()
+	. = ..()
+	deltimer(timerid)
+
+/obj/structure/holosign/barrier/atmos/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>The holofan will decay in [timeleft(timerid)/10] seconds.</span>"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3200,6 +3200,7 @@
 #include "singulostation\code\game\area\Space_Station_13_areas.dm"
 #include "singulostation\code\game\area\areas\asteroid.dm"
 #include "singulostation\code\game\objects\effects\displacement.dm"
+#include "singulostation\code\game\objects\structures\holosign.dm"
 #include "singulostation\code\modules\mob\living\death.dm"
 #include "waspstation\code\__DEFINES\DCM.dm"
 #include "waspstation\code\__DEFINES\DNA.dm"


### PR DESCRIPTION
## About The Pull Request

Makes holofirelocks decay after an hour (you can see how long you have left by examining it) and makes plastic flaps impassible to humans

## Why It's Good For The Game

Use. fucking. AACs.

## Changelog
:cl:
tweak: Holofans now decay
tweak: No more going through plastic flaps
/:cl:
