### PR TITLE
Buff construction bags

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -438,7 +438,7 @@
 /obj/item/storage/bag/construction/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_combined_w_class = 1000       //Singulostation edit - Buff construction bags
+	STR.max_combined_w_class = 400       //Singulostation edit - Buff construction bags
 	STR.max_items = 300                   //Singulostation edit - Buff construction bags
 	STR.max_w_class = WEIGHT_CLASS_NORMAL //Singulostation edit - Buff construction bags
 	STR.insert_preposition = "in"

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -438,12 +438,15 @@
 /obj/item/storage/bag/construction/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_combined_w_class = 100
-	STR.max_items = 50
-	STR.max_w_class = WEIGHT_CLASS_SMALL
+	STR.max_combined_w_class = 1000       //Singulostation edit - Buff construction bags
+	STR.max_items = 300                   //Singulostation edit - Buff construction bags
+	STR.max_w_class = WEIGHT_CLASS_NORMAL //Singulostation edit - Buff construction bags
 	STR.insert_preposition = "in"
 	STR.set_holdable(list(
 		/obj/item/stack/ore/bluespace_crystal,
+		/obj/item/stack/sheet, //Singulostation edit - Buff construction bags
+		/obj/item/stack/tile,  //Singulostation edit - Buff construction bags
+		/obj/item/stack/rods,  //Singulostation edit - Buff construction bags
 		/obj/item/assembly,
 		/obj/item/stock_parts,
 		/obj/item/reagent_containers/glass/beaker,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs construction bags to be closer to pre-rebase trashbags of holding.
Construction bag capacity raised to capacity of pre-rebase trashbag of holding.
They can now additionally hold sheets, rods and floor tiles. The maximum weight class has been upped to `WEIGHT_CLASS_NORMAL` to account for sheet stack weight class.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You need lots of materials and boards when building significant portions of the station, nobody likes running running out of space for basic materials.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Construction bags can now hold sheets, rods and floor tiles
balance: Construction bags have greatly increased capacity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
