### PR TITLE
[Ready] Fix various startup runtimes

### DIFF
--- a/_maps/RandomRuins/SandRuins/whitesands_surface_medipen_plant.dmm
+++ b/_maps/RandomRuins/SandRuins/whitesands_surface_medipen_plant.dmm
@@ -350,7 +350,7 @@
 /turf/open/floor/plasteel/dark,
 /area/whitesands/surface/outdoors/unexplored)
 "jM" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -1007,7 +1007,7 @@
 "CI" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman/super,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 8
 	},
 /turf/open/floor/plating,

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -69,6 +69,7 @@
 
 /area/ruin/unpowered/syndicate_lava_base/main
 	name = "Syndicate Lavaland Primary Hallway"
+	area_flags = HIDDEN_AREA | BLOBS_ALLOWED | UNIQUE_AREA
 
 /area/ruin/unpowered/syndicate_lava_base/cargo
 	name = "Syndicate Lavaland Cargo Bay"

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -69,7 +69,7 @@
 
 /area/ruin/unpowered/syndicate_lava_base/main
 	name = "Syndicate Lavaland Primary Hallway"
-	area_flags = HIDDEN_AREA | BLOBS_ALLOWED | UNIQUE_AREA
+	area_flags = HIDDEN_AREA | BLOBS_ALLOWED | UNIQUE_AREA // Singulo edit - Fix some runtimes
 
 /area/ruin/unpowered/syndicate_lava_base/cargo
 	name = "Syndicate Lavaland Cargo Bay"

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -25,7 +25,7 @@
 /obj/item/gun/ballistic/automatic/toy/pistol
 	name = "foam force pistol"
 	desc = "A small, easily concealable toy handgun. Ages 8 and up."
-	icon_state = "pistol"
+	icon_state = "derringer"
 	bolt_type = BOLT_TYPE_LOCKING
 	w_class = WEIGHT_CLASS_SMALL
 	mag_type = /obj/item/ammo_box/magazine/toy/pistol

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -25,7 +25,7 @@
 /obj/item/gun/ballistic/automatic/toy/pistol
 	name = "foam force pistol"
 	desc = "A small, easily concealable toy handgun. Ages 8 and up."
-	icon_state = "derringer"
+	icon_state = "derringer" // Singulo edit - Fix some runtimes
 	bolt_type = BOLT_TYPE_LOCKING
 	w_class = WEIGHT_CLASS_SMALL
 	mag_type = /obj/item/ammo_box/magazine/toy/pistol

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -201,7 +201,8 @@
 			if(isalien(L))
 				new /obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter(target_loca, splatter_dir)
 			var/obj/item/bodypart/B = L.get_bodypart(def_zone)
-			if(B.status == BODYPART_ROBOTIC) // So if you hit a robotic, it sparks instead of bloodspatters
+			// Singulostation edit - Fixes a unit test runtime
+			if(B?.status == BODYPART_ROBOTIC) // So if you hit a robotic, it sparks instead of bloodspatters
 				do_sparks(2, FALSE, target.loc)
 				if(prob(25))
 					new /obj/effect/decal/cleanable/oil(target_loca)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -201,7 +201,7 @@
 			if(isalien(L))
 				new /obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter(target_loca, splatter_dir)
 			var/obj/item/bodypart/B = L.get_bodypart(def_zone)
-			// Singulostation edit - Fixes a unit test runtime
+			// Singulo edit - Fix some runtimes
 			if(B?.status == BODYPART_ROBOTIC) // So if you hit a robotic, it sparks instead of bloodspatters
 				do_sparks(2, FALSE, target.loc)
 				if(prob(25))

--- a/whitesands/code/datums/ruins/whitesands.dm
+++ b/whitesands/code/datums/ruins/whitesands.dm
@@ -95,7 +95,7 @@
 	description = "A small encampment of nomadic survivors of the First Colony, and their descendants. By all accounts, feral and without allegance to anyone but themselves."
 	suffix = "whitesands_surface_camp_survivors.dmm"
 	cost = 2
-	placement_weight = 1.2
+	placement_weight = 12 // Singulo edit - Fix some runtimes
 	always_place = TRUE
 
 /datum/map_template/ruin/camp/whitesands/survivors/hunters
@@ -104,7 +104,7 @@
 	description = "A small encampment of nomadic hunters of the First Colony, and their descendants. It's worth steering wide of these guys."
 	suffix = "whitesands_surface_camp_hunters.dmm"
 	cost = 3
-	placement_weight = 0.8
+	placement_weight = 8 // Singulo edit - Fix some runtimes
 
 /datum/map_template/ruin/camp/whitesands/survivors/gunslingers
 	name = "Mercenary Camp"
@@ -112,7 +112,7 @@
 	description = "A small encampment of nomadic warriors of the First Colony, and their descendants. They might have the only working automatics on the planet."
 	suffix = "whitesands_surface_camp_gunslingers.dmm"
 	cost = 5
-	placement_weight = 0.7
+	placement_weight = 7 // Singulo edit - Fix some runtimes
 
 /datum/map_template/ruin/camp/whitesands/survivors/adobe
 	name = "Native Adobe"
@@ -120,7 +120,7 @@
 	description = "A semi-permanent settlement of survivors of the First Colony, and their descendants. Places like this often stash gear and supplies for their bretheren."
 	suffix = "whitesands_surface_camp_adobe.dmm"
 	cost = 10
-	placement_weight = 0.5
+	placement_weight = 5 // Singulo edit - Fix some runtimes
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/camp/whitesands/survivors/cowboy
@@ -129,5 +129,5 @@
 	description = "A frontier-style settlement founded by what can only be assumed as an offshoot of the original colony. Most inhabitants must have either moved on or died."
 	suffix = "whitesands_surface_camp_cowboy.dmm"
 	cost = 10
-	placement_weight = 0.5
+	placement_weight = 5 // Singulo edit - Fix some runtimes
 	allow_duplicates = FALSE


### PR DESCRIPTION
## About The Pull Request

Fixes this unit test runtime
```
[18:17:48] Runtime in projectile.dm,204: Cannot read null.status
  proc name: on hit (/obj/projectile/proc/on_hit)
  src: the syringe (/obj/projectile/bullet/dart/tranq)
  src.loc: the floor (39,148,5) (/turf/open/floor/wood)
  call stack:
  the syringe (/obj/projectile/bullet/dart/tranq): on hit(Lisa (/mob/living/simple_animal/pet/cat/kitten), 0)
-rest of the call stack omitted-
```
Fixes these startup runtimes
```
[2021-03-21 08:46:58.549] runtime error: Bad control_area path for Base turret controls, Syndicate Lavaland Primary Hallway
 - proc name: stack trace (/datum/proc/stack_trace)
 -   source file: unsorted.dm,1120
 -   usr: null
 -   src: Base turret controls (/obj/machinery/turretid)
 -   src.loc: the floor (206,199,5) (/turf/open/floor/circuit/red)
 -   call stack:
 - Base turret controls (/obj/machinery/turretid): stack trace("Bad control_area path for Base...")
-rest of the call stack omitted-
```
```
[2021-03-18 18:14:04.776] runtime error: /obj/item/gun/ballistic/automatic/toy/pistol/unrestricted does not have a valid icon state, icon=whitesands/icons/obj/guns/projectile.dmi, icon_state="pistol"([0x6001c7b]), icon_states=-snip-
 - proc name: stack trace (/datum/proc/stack_trace)
 -   source file: unsorted.dm,1120
 -   usr: null
 -   src: vending (/datum/asset/spritesheet/vending)
 -   call stack:
 - vending (/datum/asset/spritesheet/vending): stack trace("/obj/item/gun/ballistic/automa...")
-rest of the call stack omitted-
```
```
[2021-03-21 16:17:33.954] runtime error: Cannot read null.always_spawn_with
 - proc name: seedRuins (/proc/seedRuins)
 -   source file: ruins.dm,117
 -   usr: (src)
 -   src: null
 -   call stack:
 - seedRuins(/list (/list), 24, /list (/list), /list (/list))
 - Mapping (/datum/controller/subsystem/mapping): Initialize(586445)
 - Master (/datum/controller/master): Initialize(10, 0, 1)
 - 
```
+2 linked runtimes
```
[2021-03-21 17:07:18.583] runtime error: Cannot read null.always_spawn_with
 - proc name: seedRuins (/proc/seedRuins)
 -   source file: ruins.dm,124
 -   usr: (src)
 -   src: null
 -   call stack:
 - seedRuins(/list (/list), 30, /list (/list), /list (/list))
 - Mapping (/datum/controller/subsystem/mapping): Initialize(616306)
 - Master (/datum/controller/master): Initialize(10, 0, 1)
 - 
```

## Changelog
:cl: Urumasi
fix: Fixed some runtime errors
/:cl: