### PR TITLE
Make departmental protolathes and techfabs printable

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -270,7 +270,7 @@
 	name = "Machine Design (Circuit Imprinter Board)"
 	desc = "The circuit board for a circuit imprinter."
 	id = "circuit_imprinter"
-	build_path = /obj/item/circuitboard/machine/circuit_imprinter/department
+	build_path = /obj/item/circuitboard/machine/circuit_imprinter/department //Singulostation edit - Printable techfabs and protolathes
 	category = list("Research Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -270,7 +270,7 @@
 	name = "Machine Design (Circuit Imprinter Board)"
 	desc = "The circuit board for a circuit imprinter."
 	id = "circuit_imprinter"
-	build_path = /obj/item/circuitboard/machine/circuit_imprinter
+	build_path = /obj/item/circuitboard/machine/circuit_imprinter/department
 	category = list("Research Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -11,7 +11,10 @@
 	design_ids = list("basic_matter_bin", "basic_cell", "basic_scanning", "basic_capacitor", "basic_micro_laser", "micro_mani", "c-reader", "desttagger", "salestagger", "handlabel", "packagewrap",
 					"destructive_analyzer", "circuit_imprinter", "experimentor", "rdconsole", "bepis", "design_disk", "tech_disk", "rdserver", "rdservercontrol", "mechfab",
 					"paystand", "space_heater", "bucket", "sec_rshot", "sec_beanbag_slug", "sec_bshot", "sec_slug", "sec_Islug", "sec_dart", "sec_38", "rglass", "plasteel",
-					"plastitanium", "plasmaglass", "plasmareinforcedglass", "titaniumglass", "plastitaniumglass", "plastic_knife", "plastic_fork", "plastic_spoon")
+					"plastitanium", "plasmaglass", "plasmareinforcedglass", "titaniumglass", "plastitaniumglass", "plastic_knife", "plastic_fork", "plastic_spoon", // Singulostation Begin - Make techfabs and protolathes printable
+					"techfab_departmental_engineering", "techfab_departmental_science", "techfab_departmental_medical", "techfab_departmental_cargo", "techfab_departmental_security", "techfab_departmental_service",
+					"protolathe_departmental_engineering", "protolathe_departmental_science", "protolathe_departmental_medical", "protolathe_departmental_cargo", "protolathe_departmental_security", "protolathe_departmental_service",
+					) // Singulostation End
 
 /datum/techweb_node/mmi
 	id = "mmi"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -11,10 +11,7 @@
 	design_ids = list("basic_matter_bin", "basic_cell", "basic_scanning", "basic_capacitor", "basic_micro_laser", "micro_mani", "c-reader", "desttagger", "salestagger", "handlabel", "packagewrap",
 					"destructive_analyzer", "circuit_imprinter", "experimentor", "rdconsole", "bepis", "design_disk", "tech_disk", "rdserver", "rdservercontrol", "mechfab",
 					"paystand", "space_heater", "bucket", "sec_rshot", "sec_beanbag_slug", "sec_bshot", "sec_slug", "sec_Islug", "sec_dart", "sec_38", "rglass", "plasteel",
-					"plastitanium", "plasmaglass", "plasmareinforcedglass", "titaniumglass", "plastitaniumglass", "plastic_knife", "plastic_fork", "plastic_spoon", // Singulostation Begin - Make techfabs and protolathes printable
-					"techfab_departmental_engineering", "techfab_departmental_science", "techfab_departmental_medical", "techfab_departmental_cargo", "techfab_departmental_security", "techfab_departmental_service",
-					"protolathe_departmental_engineering", "protolathe_departmental_science", "protolathe_departmental_medical", "protolathe_departmental_cargo", "protolathe_departmental_security", "protolathe_departmental_service",
-					) // Singulostation End
+					"plastitanium", "plasmaglass", "plasmareinforcedglass", "titaniumglass", "plastitaniumglass", "plastic_knife", "plastic_fork", "plastic_spoon")
 
 /datum/techweb_node/mmi
 	id = "mmi"
@@ -147,7 +144,9 @@
 	design_ids = list("solarcontrol", "solarassembly", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "high_cell", "adv_matter_bin", "scanner_gate",
 	"atmosalerts", "atmos_control", "recycler", "autolathe", "high_micro_laser", "nano_mani", "mesons", "welding_goggles", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod",
 	"apc_control", "cell_charger", "power control", "airlock_board", "firelock_board", "aac_electronics", "airalarm_electronics", "firealarm_electronics", "cell_charger", "stack_console", "stack_machine",
-	"oxygen_tank", "plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt")	//WS edit, solar assemblies from lathe
+	"oxygen_tank", "plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt",	//WS edit, solar assemblies from lathe
+	"techfab_departmental_engineering", "techfab_departmental_science", "techfab_departmental_medical", "techfab_departmental_cargo", "techfab_departmental_security", "techfab_departmental_service", //Singulostation edit - Printable techfabs and protolathes
+	"protolathe_departmental_engineering", "protolathe_departmental_science", "protolathe_departmental_medical", "protolathe_departmental_cargo", "protolathe_departmental_security", "protolathe_departmental_service") //Singulostation edit - Printable techfabs and protolathes
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	export_price = 5000
 

--- a/singulostation/code/modules/research/designs/machine_designs.dm
+++ b/singulostation/code/modules/research/designs/machine_designs.dm
@@ -18,7 +18,7 @@
 	name = "Machine Design (Service Protolathe Board)"
 	desc = "A circuit board for a service protolathe."
 	id = "protolathe_departmental_service"
-	build_path = /obj/item/circuitboard/machine/protolathe/department/medical
+	build_path = /obj/item/circuitboard/machine/protolathe/department/service
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 	category = list("Misc. Machinery")
 
@@ -34,7 +34,7 @@
 	name = "Machine Design (Science Protolathe Board)"
 	desc = "A circuit board for a science protolathe."
 	id = "protolathe_departmental_science"
-	build_path = /obj/item/circuitboard/machine/protolathe/department/medical
+	build_path = /obj/item/circuitboard/machine/protolathe/department/science
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 	category = list("Research Machinery")
 
@@ -45,14 +45,6 @@
 	build_path = /obj/item/circuitboard/machine/protolathe/department/cargo
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 	category = list("Misc. Machinery")
-
-// /datum/design/board/circuitimprinter_departmental
-//	name = "Machine Design (Cryogenic Freezer)"
-//	desc = "A cryogenic refrigeration device capable of putting you in cryogenic freeze with the help of a nearby Cryogenic Oversight Console."
-//	id = "circuitimprinter_departmental"
-//	build_path = /obj/item/circuitboard/machine/cryogenicpod
-//	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-//	category = list("Medical Machinery")
 
 /datum/design/board/techfab_medical
 	name = "Machine Design (Medical Techfab Board)"
@@ -74,7 +66,7 @@
 	name = "Machine Design (Service Techfab Board)"
 	desc = "A circuit board for a service techfab."
 	id = "techfab_departmental_service"
-	build_path = /obj/item/circuitboard/machine/techfab/department/medical
+	build_path = /obj/item/circuitboard/machine/techfab/department/service
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 	category = list("Misc. Machinery")
 
@@ -90,7 +82,7 @@
 	name = "Machine Design (Science Techfab Board)"
 	desc = "A circuit board for a science techfab."
 	id = "techfab_departmental_science"
-	build_path = /obj/item/circuitboard/machine/techfab/department/medical
+	build_path = /obj/item/circuitboard/machine/techfab/department/science
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 	category = list("Research Machinery")
 

--- a/singulostation/code/modules/research/designs/machine_designs.dm
+++ b/singulostation/code/modules/research/designs/machine_designs.dm
@@ -93,3 +93,4 @@
 	build_path = /obj/item/circuitboard/machine/techfab/department/cargo
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 	category = list("Misc. Machinery")
+	

--- a/singulostation/code/modules/research/designs/machine_designs.dm
+++ b/singulostation/code/modules/research/designs/machine_designs.dm
@@ -1,0 +1,103 @@
+/datum/design/board/protolathe_medical
+	name = "Machine Design (Medical Protolathe Board)"
+	desc = "A circuit board for a medical protolathe."
+	id = "protolathe_departmental_medical"
+	build_path = /obj/item/circuitboard/machine/protolathe/department/medical
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	category = list("Medical Machinery")
+
+/datum/design/board/protolathe_engineering
+	name = "Machine Design (Engineering Protolathe Board)"
+	desc = "A circuit board for an engineering protolathe."
+	id = "protolathe_departmental_engineering"
+	build_path = /obj/item/circuitboard/machine/protolathe/department/engineering
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+	category = list("Engineering Machinery")
+
+/datum/design/board/protolathe_service
+	name = "Machine Design (Service Protolathe Board)"
+	desc = "A circuit board for a service protolathe."
+	id = "protolathe_departmental_service"
+	build_path = /obj/item/circuitboard/machine/protolathe/department/medical
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
+	category = list("Misc. Machinery")
+
+/datum/design/board/protolathe_security
+	name = "Machine Design (Security Protolathe Board)"
+	desc = "A circuit board for a security protolathe."
+	id = "protolathe_departmental_security"
+	build_path = /obj/item/circuitboard/machine/protolathe/department/security
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	category = list("Misc. Machinery")
+
+/datum/design/board/protolathe_science
+	name = "Machine Design (Science Protolathe Board)"
+	desc = "A circuit board for a science protolathe."
+	id = "protolathe_departmental_science"
+	build_path = /obj/item/circuitboard/machine/protolathe/department/medical
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	category = list("Research Machinery")
+
+/datum/design/board/protolathe_cargo
+	name = "Machine Design (Cargo Protolathe Board)"
+	desc = "A circuit board for a cargo protolathe."
+	id = "protolathe_departmental_cargo"
+	build_path = /obj/item/circuitboard/machine/protolathe/department/cargo
+	departmental_flags = DEPARTMENTAL_FLAG_CARGO
+	category = list("Misc. Machinery")
+
+// /datum/design/board/circuitimprinter_departmental
+//	name = "Machine Design (Cryogenic Freezer)"
+//	desc = "A cryogenic refrigeration device capable of putting you in cryogenic freeze with the help of a nearby Cryogenic Oversight Console."
+//	id = "circuitimprinter_departmental"
+//	build_path = /obj/item/circuitboard/machine/cryogenicpod
+//	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+//	category = list("Medical Machinery")
+
+/datum/design/board/techfab_medical
+	name = "Machine Design (Medical Techfab Board)"
+	desc = "A circuit board for a medical techfab."
+	id = "techfab_departmental_medical"
+	build_path = /obj/item/circuitboard/machine/techfab/department/medical
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	category = list("Medical Machinery")
+
+/datum/design/board/techfab_engineering
+	name = "Machine Design (Engineering Techfab Board)"
+	desc = "A circuit board for an engineering techfab."
+	id = "techfab_departmental_engineering"
+	build_path = /obj/item/circuitboard/machine/techfab/department/engineering
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+	category = list("Engineering Machinery")
+
+/datum/design/board/techfab_service
+	name = "Machine Design (Service Techfab Board)"
+	desc = "A circuit board for a service techfab."
+	id = "techfab_departmental_service"
+	build_path = /obj/item/circuitboard/machine/techfab/department/medical
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
+	category = list("Misc. Machinery")
+
+/datum/design/board/techfab_security
+	name = "Machine Design (Security Techfab Board)"
+	desc = "A circuit board for a security techfab."
+	id = "techfab_departmental_security"
+	build_path = /obj/item/circuitboard/machine/techfab/department/security
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	category = list("Misc. Machinery")
+
+/datum/design/board/techfab_science
+	name = "Machine Design (Science Techfab Board)"
+	desc = "A circuit board for a science techfab."
+	id = "techfab_departmental_science"
+	build_path = /obj/item/circuitboard/machine/techfab/department/medical
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	category = list("Research Machinery")
+
+/datum/design/board/techfab_cargo
+	name = "Machine Design (Cargo Techfab Board)"
+	desc = "A circuit board for a cargo techfab."
+	id = "techfab_departmental_cargo"
+	build_path = /obj/item/circuitboard/machine/techfab/department/cargo
+	departmental_flags = DEPARTMENTAL_FLAG_CARGO
+	category = list("Misc. Machinery")

--- a/singulostation/code/modules/research/designs/machine_designs.dm
+++ b/singulostation/code/modules/research/designs/machine_designs.dm
@@ -93,4 +93,3 @@
 	build_path = /obj/item/circuitboard/machine/techfab/department/cargo
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 	category = list("Misc. Machinery")
-	

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3211,6 +3211,7 @@
 #include "singulostation\code\modules\cargo\exports\tools.dm"
 #include "singulostation\code\modules\mob\living\death.dm"
 #include "singulostation\code\modules\mob\living\simple_animal\hostile\megafauna\colossus.dm"
+#include "singulostation\code\modules\research\designs\machine_designs.dm"
 #include "singulostation\code\modules\research\designs\tool_designs.dm"
 #include "singulostation\code\modules\research\xenobiology\crossbreeding\_misc.dm"
 #include "singulostation\code\modules\research\xenobiology\crossbreeding\_structures.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds departmental protolathe and techfab boards to circuit imprinter. Does not make omnilathes printable.
Also makes circuit imprinter board print the departmental one, since departmentless departmental boards are available roundstart, and the only difference is they don't require a console to use.
Available under Industrial Engineering.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Access restrictions are a myth on SinguloStation, and this allows people to build whatever departments they want with their own lathes without taking away from a limited supply.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Departmental protolathe and techfab boards are now printable.
tweak: Circuit Imprinter boards print departmental version now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
