### PR TITLE
Fix latejoin cryosleepers putting you under lobby screen logo when destroyed/unpowered

### DIFF
--- a/singulostation/code/game/machinery/cryopod.dm
+++ b/singulostation/code/game/machinery/cryopod.dm
@@ -339,14 +339,17 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	var/mob/living/L = M
 	if (ishuman(L))
 		L.SetSleeping(5 SECONDS)
+	M.forceMove(get_turf(src))
 	if(icon_state == "cryopod-open") //Don't stack people inside cryopods
 		close_machine(M, TRUE)
-	else
-		M.forceMove(get_turf(src))
 
 /obj/machinery/cryopod/latejoin/Initialize()
 	. = ..()
 	new /obj/effect/landmark/latejoin(src)
+
+/obj/machinery/cryopod/latejoin/Destroy()
+	SSjob.latejoin_trackers -= src
+	. = ..()
 
 /obj/machinery/cryopod/close_machine(mob/user, exiting = FALSE)
 	active = !exiting //If we exit, don't immediately try to put us into cryo thanks.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The code moves you to the cryosleeper's turf first, then tries to put you in. In case the code decides to put you into the sleeper, but fails to do that.
Additionally, remove destroyed latejoin cryosleepers from `SSjob.latejoin_trackers`. This is necessary because if the sleeper is destroyed, trying to move you to the sleeper's turf will put you into nullspace (resulting in you getting moved to secret room).

The PR has **not** been tested thoroughly just yet.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Actual bug that prevents people from joining the game if the station is damaged in some ways.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Unpowered cryosleepers can be spawned from.
fix: Destroyed cryosleepers are removed as possible spawn locations.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
