### PR TITLE
Add construction bags to Robco vending machines, available roundstart

### DIFF
--- a/code/modules/vending/engineering.dm
+++ b/code/modules/vending/engineering.dm
@@ -10,6 +10,7 @@
 		            /obj/item/clothing/shoes/sneakers/orange = 4,
 		            /obj/item/clothing/head/hardhat = 4,
 					/obj/item/storage/belt/utility = 4,
+					/obj/item/storage/bag/construction = 4, //Singulostation edit - Add construction bags to Robco vending machines, available roundstart
 					/obj/item/clothing/glasses/meson/engine = 4,
 					/obj/item/clothing/gloves/color/yellow = 4,
 					/obj/item/screwdriver = 12,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Add construction bags to Robco vending machines, available roundstart
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Our modified construction bags make working on big projects possible without spending half the time running back and forth from point to point to gather materials. This makes them actually available to players without spending significant time building botany and/or dumping machines that will go unused in cargo to bumrush them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Add construction bags to Robco vending machines, available roundstart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
