### PR TITLE
Make deepcore pinpointers only locate ores on the same Z-level

### DIFF
--- a/whitesands/code/game/objects/items/pinpointer.dm
+++ b/whitesands/code/game/objects/items/pinpointer.dm
@@ -27,6 +27,8 @@
 	var/located_dist
 	var/obj/effect/landmark/located_vein
 	for(var/obj/effect/landmark/I in GLOB.ore_vein_landmarks)
+		if(I.z != src.z)
+			continue
 		if(located_vein)
 			var/new_dist = get_dist(here, get_turf(I))
 			if(new_dist < located_dist)
@@ -48,6 +50,8 @@
 	//Sorts vein artifacts by ore type
 	var/viens_by_type = list()
 	for(var/obj/effect/landmark/ore_vein/I in GLOB.ore_vein_landmarks)
+		if(I.z != src.z)
+			continue
 		if(islist(viens_by_type[I.resource]))
 			var/list/L = viens_by_type[I.resource]
 			L += I

--- a/whitesands/code/game/objects/items/pinpointer.dm
+++ b/whitesands/code/game/objects/items/pinpointer.dm
@@ -27,7 +27,7 @@
 	var/located_dist
 	var/obj/effect/landmark/located_vein
 	for(var/obj/effect/landmark/I in GLOB.ore_vein_landmarks)
-		if(I.z != src.z)
+		if(I.z != src.z) // SinguloStation edit - Make pinpointers target same Z
 			continue
 		if(located_vein)
 			var/new_dist = get_dist(here, get_turf(I))
@@ -50,7 +50,7 @@
 	//Sorts vein artifacts by ore type
 	var/viens_by_type = list()
 	for(var/obj/effect/landmark/ore_vein/I in GLOB.ore_vein_landmarks)
-		if(I.z != src.z)
+		if(I.z != src.z) // SinguloStation edit - Make pinpointers target same Z
 			continue
 		if(islist(viens_by_type[I.resource]))
 			var/list/L = viens_by_type[I.resource]


### PR DESCRIPTION
## About The Pull Request

Makes the deepcore mining pinpointers only locate ore veins that are on the same Z-level.

At the moment they work as if the world was 3D, an ore vein on z=5 at the same xy coords as you on z=4 would show up as a distance of 1.

## Why It's Good For The Game

Pinpointers are fucking awful without this change, I believe this is actually a bug and not a "feature" where they're unreliable

## Changelog
:cl: Urumasi
fix: Ore vein pinpointers now correctly only show ores that are on your z-level.
/:cl:

