### PR TITLE
Fixes the infinite RCD material bug

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -155,12 +155,14 @@ RLD
 		return TRUE
 
 /obj/item/construction/proc/checkResource(amount, mob/user)
+	// SinguloStation edit begin - Infinite RCD fix
 	if(!silo_mats || !silo_mats.mat_container)
 		if(silo_link)
 			to_chat(user, "<span class='alert'>Connected silo link is invalid. Reconnect to silo via multitool.</span>")
 			return FALSE
 		else
 			. = matter >= amount
+	// SinguloStation edit end - Infinite RCD fix
 	else
 		if(silo_mats.on_hold())
 			if(user)
@@ -264,7 +266,7 @@ RLD
 
 /obj/item/construction/rcd/proc/toggle_silo_link(mob/user)
 	if(silo_mats)
-		if(!silo_mats.mat_container && !silo_link)
+		if(!silo_mats.mat_container && !silo_link) // SinguloStation edit - Infinite RCD fix
 			to_chat(user, "<span class='alert'>No silo link detected. Connect to silo via multitool.</span>")
 			return FALSE
 		silo_link = !silo_link

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -155,8 +155,12 @@ RLD
 		return TRUE
 
 /obj/item/construction/proc/checkResource(amount, mob/user)
-	if(!silo_link || !silo_mats || !silo_mats.mat_container)
-		. = matter >= amount
+	if(!silo_mats || !silo_mats.mat_container)
+		if(silo_link)
+			to_chat(user, "<span class='alert'>Connected silo link is invalid. Reconnect to silo via multitool.</span>")
+			return FALSE
+		else
+			. = matter >= amount
 	else
 		if(silo_mats.on_hold())
 			if(user)
@@ -260,7 +264,7 @@ RLD
 
 /obj/item/construction/rcd/proc/toggle_silo_link(mob/user)
 	if(silo_mats)
-		if(!silo_mats.mat_container)
+		if(!silo_mats.mat_container && !silo_link)
 			to_chat(user, "<span class='alert'>No silo link detected. Connect to silo via multitool.</span>")
 			return FALSE
 		silo_link = !silo_link


### PR DESCRIPTION
## About The Pull Request

Fixes a bug where if your silo link invalidated while it was on, you could build infinitely since the mat check would be from the internal buffer but it would attempt to deduct mats from the invalid silo link, failing silently.

## Why It's Good For The Game

Free materials bad

## Changelog
:cl: Urumasi
fix: Fixed a bug where the RCD could be used for free
/:cl:
