### PR TITLE
Fix mindbreaker toxin not stopping Reality Dissociation Syndrome

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -241,7 +241,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_GRABWEAKNESS		"grab_weakness"
 #define TRAIT_SNOB				"snob"
 #define TRAIT_BALD				"bald"
-#define TRAIT_INSANITY			"insanity"
+#define TRAIT_INSANITY			"insanity" // SinguloStation edit - Fix mindbreaker toxin curing RDS
 
 // common trait sources
 #define TRAIT_GENERIC "generic"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -241,6 +241,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_GRABWEAKNESS		"grab_weakness"
 #define TRAIT_SNOB				"snob"
 #define TRAIT_BALD				"bald"
+#define TRAIT_INSANITY			"insanity"
 
 // common trait sources
 #define TRAIT_GENERIC "generic"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -397,7 +397,7 @@
 	name = "Reality Dissociation Syndrome"
 	desc = "You suffer from a severe disorder that causes very vivid hallucinations. Mindbreaker toxin can suppress its effects, and you are immune to mindbreaker's hallucinogenic properties. <b>This is not a license to grief.</b>"
 	value = -2
-	mob_trait = TRAIT_INSANITY
+	mob_trait = TRAIT_INSANITY // SinguloStation edit - Fix mindbreaker toxin curing RDS
 	gain_text = "<span class='userdanger'>...</span>"
 	lose_text = "<span class='notice'>You feel in tune with the world again.</span>"
 	medical_record_text = "Patient suffers from acute Reality Dissociation Syndrome and experiences vivid hallucinations."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -397,7 +397,7 @@
 	name = "Reality Dissociation Syndrome"
 	desc = "You suffer from a severe disorder that causes very vivid hallucinations. Mindbreaker toxin can suppress its effects, and you are immune to mindbreaker's hallucinogenic properties. <b>This is not a license to grief.</b>"
 	value = -2
-	//no mob trait because it's handled uniquely
+	mob_trait = TRAIT_INSANITY
 	gain_text = "<span class='userdanger'>...</span>"
 	lose_text = "<span class='notice'>You feel in tune with the world again.</span>"
 	medical_record_text = "Patient suffers from acute Reality Dissociation Syndrome and experiences vivid hallucinations."

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -251,7 +251,7 @@
 	taste_description = "sourness"
 
 /datum/reagent/toxin/mindbreaker/on_mob_life(mob/living/carbon/M)
-	if(!HAS_TRAIT(M, TRAIT_INSANITY))
+	if(!HAS_TRAIT(M, TRAIT_INSANITY)) // SinguloStation edit - Fix mindbreaker toxin curing RDS
 		M.hallucination += 5
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -251,7 +251,8 @@
 	taste_description = "sourness"
 
 /datum/reagent/toxin/mindbreaker/on_mob_life(mob/living/carbon/M)
-	M.hallucination += 5
+	if(!HAS_TRAIT(M, TRAIT_INSANITY))
+		M.hallucination += 5
 	return ..()
 
 /datum/reagent/toxin/plantbgone


### PR DESCRIPTION
## About The Pull Request

Before this, mindbreaker toxin would still give 5 hallucination per tick, which would still count for hallucination generation before it gets removed by the quirk

## Changelog
:cl: Urumasi
fix: Reality Dissociation Syndrome is now really cured with mindbreaker toxin.
/:cl: