### PR TITLE
Port "adding a hack wire to the quantum pad" from beestation

### DIFF
--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -22,6 +22,7 @@
 
 /obj/machinery/quantumpad/Initialize()
 	. = ..()
+	wires = new /datum/wires/quantum_pad(src) //Singulostation edit - Quantum pad wires
 	if(map_pad_id)
 		mapped_quantum_pads[map_pad_id] = src
 
@@ -53,6 +54,11 @@
 /obj/machinery/quantumpad/attackby(obj/item/I, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "pad-idle-o", "qpad-idle", I))
 		return
+	//Singulostation begin - Quantum pad wires
+	else if(panel_open && I.tool_behaviour == TOOL_WIRECUTTER)
+		wires.interact(user)
+		return TRUE
+	//Singulostation end - Quantum pad wires
 
 	if(panel_open)
 		if(I.tool_behaviour == TOOL_MULTITOOL)

--- a/singulostation/code/datums/wires/quantum_pad.dm
+++ b/singulostation/code/datums/wires/quantum_pad.dm
@@ -1,0 +1,17 @@
+/datum/wires/quantum_pad
+	holder_type = /obj/machinery/quantumpad
+
+/datum/wires/quantum_pad/New(atom/holder)
+	wires = list(WIRE_ACTIVATE)
+	..()
+
+/datum/wires/quantum_pad/on_pulse(wire)
+	var/obj/machinery/quantumpad/Q = holder
+	switch(wire)
+		if(WIRE_ACTIVATE)
+			if(Q.panel_open)
+				holder.visible_message("<span class='notice'>[icon2html(Q, viewers(holder))] The activation light flickers.</span>")
+				return
+			else
+				Q.interact()
+	..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3201,6 +3201,7 @@
 #include "singulostation\code\datums\shuttles.dm"
 #include "singulostation\code\datums\mapgen\Asteroidgens\AsteroidGenerator.dm"
 #include "singulostation\code\datums\status_effects\misc_effects.dm"
+#include "singulostation\code\datums\wires\quantum_pad.dm"
 #include "singulostation\code\game\area\Space_Station_13_areas.dm"
 #include "singulostation\code\game\area\areas\asteroid.dm"
 #include "singulostation\code\game\machinery\cryopod.dm"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/BeeStation/BeeStation-Hornet/pull/2323
Adds wires to quantum pad, accessible via wirecutter tool while panel is open. The only wire activates the quantum pad when pulsed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows attaching assemblies to quantum pads to activate them automatically for fun contraptions like voice-activated quantum pads.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add:quantum pad wire datum
add:quantum pad machine interaction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
