### PR TITLE
Increase cable coil stack size 10x and allow recoloring

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -484,7 +484,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 	item_state = "coil"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	max_amount = MAXCOIL
+	max_amount = MAXCOIL * 10 //Singulostation edit - Cable coil buffs
 	amount = MAXCOIL
 	merge_type = /obj/item/stack/cable_coil // This is here to let its children merge between themselves
 	var/cable_color = "red"
@@ -501,6 +501,20 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 	full_w_class = WEIGHT_CLASS_SMALL
 	grind_results = list(/datum/reagent/copper = 2) //2 copper per cable in the coil
 	usesound = 'sound/items/deconstruct.ogg'
+
+//Singulostation begin - Cable coil buffs
+/obj/item/stack/cable_coil/verb/cable_recolor()
+	set name = "Change color"
+	set category = "Object"
+	set src in view(1)
+
+	if(!ishuman(usr))
+		return
+
+	var/selected_color = input(usr,"Pick a cable color.","Cable Color") in list("red","yellow","green","blue","pink","orange","cyan","white")
+	cable_color = selected_color
+	update_icon()
+//Singulostation end - Cable coil buffs
 
 /obj/item/stack/cable_coil/cyborg
 	is_cyborg = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cable coil stack size buffed from 30 to 300
Cable coils can be recolored by right-clicking and selecting "Change color" while in-hand or on the ground nearby.

Note: this PR does not change `MAXCOIL` due to the fact that `MAXCOIL` is used for various things besides the stack size itself, including the starting count of coils in a stack (for example in joining player toolbelts) and crafting recipes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The main purpose is allowing easy access to cable coils of arbitrary color in large quantities, which itself doesn't affect balance since it's a visual change. The stack size buff stems from the fact that it's the easiest way to enable it without affecting balance significantly, since cable coils can already be carried in large quantities in construction bags.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Cable coils can be recolored via a right-click verb
balance: Cable coil stack size increased from 30 to 300
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
