### PR TITLE
Make smoke machine rotatable

### DIFF
--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -36,6 +36,13 @@
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		reagents.maximum_volume += REAGENTS_BASE_VOLUME * B.rating
 
+	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated)) //Singulostation edit - Smoke machine rotation
+
+//Singulostation begin - Smoke machine rotation
+/obj/machinery/smoke_machine/proc/can_be_rotated(mob/user,rotation_type)
+	return !anchored
+//Singulostation end - Smoke machine rotation
+
 /obj/machinery/smoke_machine/update_icon_state()
 	if((!is_operational()) || (!on) || (reagents.total_volume == 0))
 		if (panel_open)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the `simple_rotation` component to smoke machines. This is the same thing that makes plumbing machines rotatable. Alt-click rotates clockwise, right-click menu has clockwise and counter-clockwise rotation verbs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Getting smoke machines facing the right way was needlessly difficult in compact setups, and a single keypress could ruin your build and require you to either tear down the surroundings of a smoke machine to rotate it by pushing it, or use bluespace launchpads to teleport smoke machines already pre-rotated in the correct direction.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Smoke machines can now be rotated via alt-click or right-click verbs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
