### PR TITLE
Disable stale PR auto-close

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being auto closed in ~ 14 days, please address any outstanding review items and ensure your PR is finished, if these are all true and you are auto-staled anyway, you need to actively ask maintainers if your PR will be merged. Once you have done any of the previous actions then you should request a maintainer remove the stale label on your PR, to reset the stale timer. If you feel no maintainer will respond in that time, you may wish to close this PR youself, while you seek maintainer comment, as you will then be able to reopen the PR yourself"
+        stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being closed by a maintainer if it is not updated or reviews are not addressed. If your PR is closed as stale, feel free to open a new one after dealing with the issues. This may also be an indication that the maintainers do not have interest in this change, you can try to convince them otherwise, or persist in the doomed world you have created."
         days-before-stale: 7
         stale-pr-label: 'Stale'
         exempt-pr-label: 'RED LABEL'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,6 +15,5 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being auto closed in ~ 14 days, please address any outstanding review items and ensure your PR is finished, if these are all true and you are auto-staled anyway, you need to actively ask maintainers if your PR will be merged. Once you have done any of the previous actions then you should request a maintainer remove the stale label on your PR, to reset the stale timer. If you feel no maintainer will respond in that time, you may wish to close this PR youself, while you seek maintainer comment, as you will then be able to reopen the PR yourself"
         days-before-stale: 7
-        days-before-close: 14
         stale-pr-label: 'Stale'
         exempt-pr-label: 'RED LABEL'


### PR DESCRIPTION
## About The Pull Request

Disables the auto-close feature of stale PRs
Also updates the stale message to reflect the removal of auto-close, using the old /tg/ stale message

## Changelog
N/A
