### PR TITLE
Temporarily disable quantum pad and broken light spark effect

### DIFF
--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -125,9 +125,15 @@
 	doteleport(user, target_pad)
 
 /obj/machinery/quantumpad/proc/sparks()
+	// Singulostation begin - Temporary removal of quantum pad sparks
+	// This change shouldn't really exist, but quantum sparks are
+	// for some reason stubbornly refusing to qdel and garbage collect
+	/*
 	var/datum/effect_system/spark_spread/quantum/s = new /datum/effect_system/spark_spread/quantum
 	s.set_up(5, 1, get_turf(src))
 	s.start()
+	*/
+	// Singulostation end - Temporary removal of quantum pad sparks
 
 /obj/machinery/quantumpad/attack_ghost(mob/dead/observer/ghost)
 	. = ..()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -437,11 +437,11 @@
 	update()
 
 /obj/machinery/light/proc/broken_sparks(start_only=FALSE)
-	if(!QDELETED(src) && status == LIGHT_BROKEN && has_power())
+	/*if(!QDELETED(src) && status == LIGHT_BROKEN && has_power())
 		if(!start_only)
 			do_sparks(3, TRUE, src)
 		var/delay = rand(BROKEN_SPARKS_MIN, BROKEN_SPARKS_MAX)
-		addtimer(CALLBACK(src, .proc/broken_sparks), delay, TIMER_UNIQUE | TIMER_NO_HASH_WAIT)
+		addtimer(CALLBACK(src, .proc/broken_sparks), delay, TIMER_UNIQUE | TIMER_NO_HASH_WAIT)*/
 
 /obj/machinery/light/process()
 	if (!cell)


### PR DESCRIPTION
## About The Pull Request

Removes the quantum pad's spark effect from showing up when you use the pad and passive broken lightbulb's spark effect. The sparks themselves are for some reason stubbornly refusing to qdel in peace, so until we find the cause of this, this disables them completely.

## Why It's Good For The Game

Over time, sparks would build up anyone rendering them would have their FPS drop down to 2 and see a massive orange glow around them

## Changelog
:cl:
del: Temporarily disabled quantum pad and broken lightbulb spark effect until we figure out why they're broken.
/:cl:
