### PR TITLE
Fix hilbert's analyzer icon

### DIFF
--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -420,6 +420,7 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 /obj/item/analyzer/hilbertsanalyzer
     name = "custom rigged analyzer"
     desc = "A hand-held environmental scanner which reports current gas levels. This one seems custom rigged to additionally be able to analyze some sort of bluespace device."
+    icon = 'icons/obj/device.dmi'
     icon_state = "hilbertsanalyzer"
 
 /obj/item/analyzer/hilbertsanalyzer/afterattack(atom/target, mob/user, proximity)


### PR DESCRIPTION
## About The Pull Request

Whitesands updating the analyzer's icon affected the hilber's analyzer's icon, since it's a subtype, making it invisible.
Closes #56

## Changelog
:cl:
fix: Hilbert's analyzer now has an icon again.
/:cl: