### PR TITLE
Slime crystals bugfix

### DIFF
--- a/singulostation/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/singulostation/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -20,11 +20,8 @@
 	
 	// The stack will be filled by the remaining amount of material needed, or amount left in the crystal, whichever is lower.
 	// This is to make sure we don't add more material than is intended by the crystal nor exceed the sheet stack size.
+	// Temporary variable to increase the item stack
 	var/amt_to_add = min(stack_item.max_amount - stack_item.get_amount(), amt)
-	// This needs to be a temporary variable so that we can properly adjust the amt variable later.
-
 	stack_item.add(amt_to_add)
-	
-	// This makes the crystals more convinent to use, as you will never spend more than is needed to increase the amount of materials.
 	amt -= amt_to_add
 	if (amt <= 0) qdel(src)

--- a/singulostation/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/singulostation/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -18,6 +18,10 @@
 		qdel(src)
 		return
 	
+	var/amt_to_add = min(stack_item.max_amount - stack_item.get_amount(), amt)
+    stack_item.add(amt_to_add)
+    amt -= amt_to_add
+	
 	new target.type(get_turf(target), amt)
 	
 	qdel(src)

--- a/singulostation/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/singulostation/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -22,6 +22,7 @@
     stack_item.add(amt_to_add)
     amt -= amt_to_add
 	
-	new target.type(get_turf(target), amt)
+    if(amt > 0)
+	    new target.type(get_turf(target), amt)
 	
 	qdel(src)

--- a/singulostation/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/singulostation/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -22,7 +22,7 @@
 	stack_item.add(amt_to_add)
 	amt -= amt_to_add
 	
-    if(amt > 0)
-	    new target.type(get_turf(target), amt)
+	if(amt > 0)
+		new target.type(get_turf(target), amt)
 	
 	qdel(src)

--- a/singulostation/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/singulostation/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -17,7 +17,14 @@
 		carbie.gain_trauma(/datum/brain_trauma/special/beepsky,TRAUMA_RESILIENCE_ABSOLUTE)
 		qdel(src)
 		return
+	
+	// The stack will be filled by the remaining amount of material needed, or amount left in the crystal, whichever is lower.
+	// This is to make sure we don't add more material than is intended by the crystal nor exceed the sheet stack size.
+	var/amt_to_add = min(stack_item.max_amount - stack_item.get_amount(), amt)
+	// This needs to be a temporary variable so that we can properly adjust the amt variable later.
 
-	stack_item.add(amt)
-
-	qdel(src)
+	stack_item.add(amt_to_add)
+	
+	// This makes the crystals more convinent to use, as you will never spend more than is needed to increase the amount of materials.
+	amt -= amt_to_add
+	if (amt <= 0) qdel(src)

--- a/singulostation/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/singulostation/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -19,8 +19,8 @@
 		return
 	
 	var/amt_to_add = min(stack_item.max_amount - stack_item.get_amount(), amt)
-    stack_item.add(amt_to_add)
-    amt -= amt_to_add
+	stack_item.add(amt_to_add)
+	amt -= amt_to_add
 	
     if(amt > 0)
 	    new target.type(get_turf(target), amt)

--- a/singulostation/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/singulostation/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -18,10 +18,6 @@
 		qdel(src)
 		return
 	
-	// The stack will be filled by the remaining amount of material needed, or amount left in the crystal, whichever is lower.
-	// This is to make sure we don't add more material than is intended by the crystal nor exceed the sheet stack size.
-	// Temporary variable to increase the item stack
-	var/amt_to_add = min(stack_item.max_amount - stack_item.get_amount(), amt)
-	stack_item.add(amt_to_add)
-	amt -= amt_to_add
-	if (amt <= 0) qdel(src)
+	new target.type(get_turf(target), amt)
+	
+	qdel(src)


### PR DESCRIPTION
## About The Pull Request

This PR fixes issue #27 by limiting the number of materials that can be added to sheets based on the amount that those sheets already have, while making sure that the slime crystals are never wasted.

## Why It's Good For The Game

This prevents sheet stacks from having more materials than intended.

## Changelog
:cl:
fix: fixed cerulean slime crystals going over sheet stack maximums
/:cl: