### PR TITLE
Construction station Solar Control Computer starts out auto-tracking

### DIFF
--- a/_maps/map_files/ConstructionStation/ConstructionStation.dmm
+++ b/_maps/map_files/ConstructionStation/ConstructionStation.dmm
@@ -1511,7 +1511,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/solar_control,
+/obj/machinery/power/solar_control/auto_connect,
 /turf/open/floor/plating,
 /area/engine/storage_shared)
 "Hr" = (

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -436,6 +436,12 @@
 ///from base power_change() when power is restored
 #define COMSIG_MACHINERY_POWER_RESTORED "machinery_power_restored"
 
+// /obj/machinery/power signals
+
+// Singulostation edit - powernet signal to machines on init
+///from /datum/controller/subsystem/machines/proc/makepowernets()
+#define COMSIG_MACHINE_POWERNET_ROUNDSTART_INIT "machine_powernet_roundstart_init"
+
 // /obj/machinery/power/supermatter_crystal signals
 /// from /obj/machinery/power/supermatter_crystal/process_atmos(); when the SM delam reaches the point of sounding alarms
 #define COMSIG_SUPERMATTER_DELAM_START_ALARM "sm_delam_start_alarm"

--- a/code/controllers/subsystem/machines.dm
+++ b/code/controllers/subsystem/machines.dm
@@ -22,6 +22,10 @@ SUBSYSTEM_DEF(machines)
 			NewPN.add_cable(PC)
 			propagate_network(PC,PC.powernet)
 
+			// Singulostation edit - powernet signal to machines on init
+			for(var/obj/machinery/power/machine in NewPN.nodes)
+				SEND_SIGNAL(machine, COMSIG_MACHINE_POWERNET_ROUNDSTART_INIT)
+
 /datum/controller/subsystem/machines/stat_entry(msg)
 	msg = "M:[length(processing)]|PN:[length(powernets)]"
 	return ..()
@@ -57,6 +61,10 @@ SUBSYSTEM_DEF(machines)
 			var/datum/powernet/NewPN = new()
 			NewPN.add_cable(PC)
 			propagate_network(PC,PC.powernet)
+
+			// Singulostation edit - powernet signal to machines on init
+			for(var/obj/machinery/power/machine in NewPN.nodes)
+				SEND_SIGNAL(machine, COMSIG_MACHINE_POWERNET_ROUNDSTART_INIT)
 
 /datum/controller/subsystem/machines/Recover()
 	if (istype(SSmachines.processing))

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -479,6 +479,25 @@
 	for(var/obj/machinery/power/solar/S in connected_panels)
 		S.queue_turn(azimuth)
 
+// Singulostation edit begin - autoconnect solar panel computers
+//
+// Solar Control Computer that automatically connects to solar panels roundstart
+//
+
+/obj/machinery/power/solar_control/auto_connect
+
+/obj/machinery/power/solar_control/auto_connect/Initialize(mapload)
+	. = ..()
+	if(mapload)
+		RegisterSignal(src, COMSIG_MACHINE_POWERNET_ROUNDSTART_INIT, .proc/auto_connect)
+
+/obj/machinery/power/solar_control/auto_connect/proc/auto_connect()
+	SIGNAL_HANDLER
+	search_for_connected()
+	track = SOLAR_TRACK_AUTO
+
+// Singulostation edit end - autoconnect solar panel computers
+
 //
 // MISC
 //

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -479,25 +479,6 @@
 	for(var/obj/machinery/power/solar/S in connected_panels)
 		S.queue_turn(azimuth)
 
-// Singulostation edit begin - autoconnect solar panel computers
-//
-// Solar Control Computer that automatically connects to solar panels roundstart
-//
-
-/obj/machinery/power/solar_control/auto_connect
-
-/obj/machinery/power/solar_control/auto_connect/Initialize(mapload)
-	. = ..()
-	if(mapload)
-		RegisterSignal(src, COMSIG_MACHINE_POWERNET_ROUNDSTART_INIT, .proc/auto_connect)
-
-/obj/machinery/power/solar_control/auto_connect/proc/auto_connect()
-	SIGNAL_HANDLER
-	search_for_connected()
-	track = SOLAR_TRACK_AUTO
-
-// Singulostation edit end - autoconnect solar panel computers
-
 //
 // MISC
 //

--- a/singulostation/code/modules/power/solar.dm
+++ b/singulostation/code/modules/power/solar.dm
@@ -4,10 +4,13 @@
 
 /obj/machinery/power/solar_control/auto_connect/Initialize(mapload)
 	. = ..()
+	if(connected_tracker)
+		track = SOLAR_TRACK_AUTO
 	if(mapload)
 		RegisterSignal(src, COMSIG_MACHINE_POWERNET_ROUNDSTART_INIT, .proc/auto_connect)
 
 /obj/machinery/power/solar_control/auto_connect/proc/auto_connect()
 	SIGNAL_HANDLER
 	search_for_connected()
-	track = SOLAR_TRACK_AUTO
+	if(connected_tracker)
+		track = SOLAR_TRACK_AUTO

--- a/singulostation/code/modules/power/solar.dm
+++ b/singulostation/code/modules/power/solar.dm
@@ -1,0 +1,13 @@
+//
+// Solar Control Computer that automatically connects to solar panels roundstart
+//
+
+/obj/machinery/power/solar_control/auto_connect/Initialize(mapload)
+	. = ..()
+	if(mapload)
+		RegisterSignal(src, COMSIG_MACHINE_POWERNET_ROUNDSTART_INIT, .proc/auto_connect)
+
+/obj/machinery/power/solar_control/auto_connect/proc/auto_connect()
+	SIGNAL_HANDLER
+	search_for_connected()
+	track = SOLAR_TRACK_AUTO

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3213,6 +3213,7 @@
 #include "singulostation\code\modules\cargo\exports\tools.dm"
 #include "singulostation\code\modules\mob\living\death.dm"
 #include "singulostation\code\modules\mob\living\simple_animal\hostile\megafauna\colossus.dm"
+#include "singulostation\code\modules\power\solar.dm"
 #include "singulostation\code\modules\research\designs\machine_designs.dm"
 #include "singulostation\code\modules\research\designs\tool_designs.dm"
 #include "singulostation\code\modules\research\xenobiology\crossbreeding\_misc.dm"


### PR DESCRIPTION
## About The Pull Request

Creates a variant of the Solar Control Computer that starts the round searching for solar panels and enabling auto-tracking, and replaces the computer on Construction station.
Also adds a signal to powered machines whenever the powernet they're connected to initializes for the first time at mapload, since powernets are created after atoms initialize.

## Why It's Good For The Game

At roundstart, if nobody enables the solar panels and goes AFK, the arrivals cryo could depower, not allowing anyone else to late-join, and it's not hard to forget to enable it either way.

## Changelog
:cl:
add: Solar control computers now start out tracking the sun on construction station
code: Added a signal to powered machines when the cable below them initializes a powernet at mapload
/:cl: