### PR TITLE
Stops recyclers from eating effects

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -130,14 +130,16 @@
 		playsound(src, item_recycle_sound, (50 + nom.len*5), TRUE, nom.len, ignore_walls = (nom.len - 10)) // As a substitute for playing 50 sounds at once.
 	if(not_eaten)
 		playsound(src, 'sound/machines/buzz-sigh.ogg', (50 + not_eaten*5), FALSE, not_eaten, ignore_walls = (not_eaten - 10)) // Ditto.
-	if(!ismob(AM0))
-		AM0.moveToNullspace()
-		qdel(AM0)
-	else // Lets not move a mob to nullspace and qdel it, yes?
+	// SinguloStation edit begin - Stop recycler form recycling effects
+	if(ismob(AM0)) // Lets not move a mob to nullspace and qdel it, yes?
 		for(var/i in AM0.contents)
 			var/atom/movable/content = i
 			content.moveToNullspace()
-			qdel(content)
+			qdel(content
+	else if(!istype(AM0, /obj/effect))
+		AM0.moveToNullspace()
+		qdel(AM0)
+	// SinguloStation edit end - Stop recycler form recycling effects
 
 /obj/machinery/recycler/proc/recycle_item(obj/item/I)
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -103,6 +103,8 @@
 	var/living_detected = FALSE //technically includes silicons as well but eh
 	var/list/nom = list()
 	var/list/crunchy_nom = list() //Mobs have to be handled differently so they get a different list instead of checking them multiple times.
+	// SinguloStation edit - Stop recycler form recycling effects
+	var/dont_nom_count = 0 //Count things like effects that we can't eat, so we don't buzz when we don't accept it
 
 	for(var/i in to_eat)
 		var/atom/movable/AM = i
@@ -115,7 +117,11 @@
 		else if(isliving(AM))
 			living_detected = TRUE
 			crunchy_nom += AM
-	var/not_eaten = to_eat.len - nom.len - crunchy_nom.len
+	// SinguloStation edit begin - Stop recycler form recycling effects
+		else if(istype(AM, /obj/effect))
+			dont_nom_count++
+	var/not_eaten = to_eat.len - nom.len - crunchy_nom.len - dont_nom_count
+	// SinguloStation edit end - Stop recycler form recycling effects
 	if(living_detected) // First, check if we have any living beings detected.
 		if(obj_flags & EMAGGED)
 			for(var/CRUNCH in crunchy_nom) // Eat them and keep going because we don't care about safety.
@@ -135,7 +141,7 @@
 		for(var/i in AM0.contents)
 			var/atom/movable/content = i
 			content.moveToNullspace()
-			qdel(content
+			qdel(content)
 	else if(!istype(AM0, /obj/effect))
 		AM0.moveToNullspace()
 		qdel(AM0)


### PR DESCRIPTION
## About The Pull Request

Recyclers could eat any effect including the helmet light on hardsuits, in some cases irreversibly breaking the light feature.
Fixes #65 

## Changelog
:cl:
fix: We have recalibrated recyclers to stop them from eating your hardsuit helmet lights.
/:cl: