### PR TITLE
Fix directional firelocks blocking turf under them

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -344,6 +344,8 @@
 				M.start_pulling(M2)
 	. = ..()
 
+	flags_1 &= ~PREVENT_CLICK_UNDER_1 //Singulostation edit - Fix directional firelocks blocking turf under them
+
 /obj/machinery/door/firedoor/border_only/allow_hand_open(mob/user)
 	var/area/A = get_area(src)
 	if((!A || !A.fire) && !is_holding_pressure())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/SinguloStation13/SinguloStation13/issues/72
Fixes the issue in a dirty way by forcefully removing the `PREVENT_CLICK_UNDER_1` flag from the firelock after it closes. This causes the firelock to obscure the tile under it briefly as the airlock code sleeps after setting it, but allows you to work on a turf with a closed directional firelock.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes a bug that impedes construction.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Direcitonal firelocks no longer block the turf they're on from all directions when closed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
