### PR TITLE
Fix custom shuttle mass calculation

### DIFF
--- a/whitesands/code/modules/overmap/ships/simulated.dm
+++ b/whitesands/code/modules/overmap/ships/simulated.dm
@@ -177,8 +177,9 @@
 /obj/structure/overmap/ship/simulated/proc/calculate_mass()
 	. = 0
 	var/list/areas = shuttle.shuttle_areas
-	for(var/shuttleArea in areas)
-		. += length(get_area_turfs(shuttleArea))
+	for(var/area/shuttleArea in areas)
+		for(var/turf/T in shuttleArea.contents)
+			. += 1
 	mass = .
 	update_icon_state()
 

--- a/whitesands/code/modules/overmap/ships/simulated.dm
+++ b/whitesands/code/modules/overmap/ships/simulated.dm
@@ -177,9 +177,11 @@
 /obj/structure/overmap/ship/simulated/proc/calculate_mass()
 	. = 0
 	var/list/areas = shuttle.shuttle_areas
+	//Singulostation begin - Fix shuttle mass calculation
 	for(var/area/shuttleArea in areas)
 		for(var/turf/T in shuttleArea.contents)
 			. += 1
+	//Singulostation end
 	mass = .
 	update_icon_state()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Due to a code oversight, custom shuttles currently calculate mass based on amount of tiles in the type of the shuttle's area. Because all custom shuttles' areas have the same types, this means the mass uses the sum of **all** custom shuttle areas.

This PR replaces the proc call that gets the turfs with a simple implementation that specifically iterates over the turfs of the shuttle's areas.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix is good. Also, all shuttles will now no longer be ridiculously heavy as soon as one person builds a big shuttle.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Shuttle mass calculation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
