### PR TITLE
Arm augment rework

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1065,6 +1065,12 @@
 	else if(can_be_firemanned(target))
 		fireman_carry(target)
 
+/mob/living/carbon/human/limb_attack_self()
+	var/obj/item/bodypart/arm = hand_bodyparts[active_hand_index]
+	if(arm)
+		arm.attack_self(src)
+	return ..()
+
 
 //src is the user that will be carrying, target is the mob to be carried
 /mob/living/carbon/human/proc/can_piggyback(mob/living/carbon/target)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1065,11 +1065,13 @@
 	else if(can_be_firemanned(target))
 		fireman_carry(target)
 
+//Singulostation begin - Implement tg arm augment refactors
 /mob/living/carbon/human/limb_attack_self()
 	var/obj/item/bodypart/arm = hand_bodyparts[active_hand_index]
 	if(arm)
 		arm.attack_self(src)
 	return ..()
+//Singulostation end
 
 
 //src is the user that will be carrying, target is the mob to be carried

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -603,6 +603,7 @@
 
 	return TRUE
 
+//Singulostation begin - Implement tg arm augment refactors
 /**
   * Called by using Activate Held Object with an empty hand/limb
   *
@@ -612,6 +613,7 @@
   */
 /mob/proc/limb_attack_self()
 	return
+//Singulostation end
 
 ///Can this mob resist (default FALSE)
 /mob/proc/can_resist()
@@ -665,9 +667,9 @@
 	if(I)
 		I.attack_self(src)
 		update_inv_hands()
-		return
+		return //Singulostation edit - Implement tg arm augment refactors
 
-	limb_attack_self()
+	limb_attack_self() //Singulostation edit - Implement tg arm augment refactors
 
 
 /**

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -603,6 +603,16 @@
 
 	return TRUE
 
+/**
+  * Called by using Activate Held Object with an empty hand/limb
+  *
+  * Does nothing by default. The intended use is to allow limbs to call their
+  * own attack_self procs. It is up to the individual mob to override this
+  * parent and actually use it.
+  */
+/mob/proc/limb_attack_self()
+	return
+
 ///Can this mob resist (default FALSE)
 /mob/proc/can_resist()
 	return FALSE		//overridden in living.dm
@@ -655,6 +665,10 @@
 	if(I)
 		I.attack_self(src)
 		update_inv_hands()
+		return
+
+	limb_attack_self()
+
 
 /**
   * Get the notes of this mob

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -36,7 +36,6 @@
 
 	update_icon()
 	SetSlotFromZone()
-	items_list = contents.Copy()
 
 /obj/item/organ/cyberimp/arm/Destroy()
 	hand = null
@@ -188,6 +187,7 @@
 				if(!augment_item)
 					items_list -= augment_ref
 					continue
+				choice_list[augment_item] = image(augment_item)
 			var/obj/item/choice = show_radial_menu(owner, owner, choice_list)
 			if(owner && owner == usr && owner.stat != DEAD && (src in owner.internal_organs) && !active_item && (choice in contents))
 				// This monster sanity check is a nice example of how bad input is.
@@ -215,7 +215,7 @@
 	name = "arm-mounted laser implant"
 	desc = "A variant of the arm cannon implant that fires lethal laser beams. The cannon emerges from the subject's arm and remains inside when not in use."
 	icon_state = "arm_laser"
-	items_to_create = newlist(/obj/item/gun/energy/laser/mounted)
+	items_to_create = list(/obj/item/gun/energy/laser/mounted)
 
 /obj/item/organ/cyberimp/arm/gun/laser/l
 	zone = BODY_ZONE_L_ARM
@@ -230,7 +230,7 @@
 	name = "arm-mounted taser implant"
 	desc = "A variant of the arm cannon implant that fires electrodes and disabler shots. The cannon emerges from the subject's arm and remains inside when not in use."
 	icon_state = "arm_taser"
-	items_to_create = newlist(/obj/item/gun/energy/e_gun/advtaser/mounted)
+	items_to_create = list(/obj/item/gun/energy/e_gun/advtaser/mounted)
 
 /obj/item/organ/cyberimp/arm/gun/taser/l
 	zone = BODY_ZONE_L_ARM
@@ -238,7 +238,7 @@
 /obj/item/organ/cyberimp/arm/toolset
 	name = "integrated toolset implant"
 	desc = "A stripped-down version of the engineering cyborg toolset, designed to be installed on subject's arm. Contain advanced versions of every tool."
-	items_to_create = newlist(/obj/item/screwdriver/cyborg, /obj/item/wrench/cyborg, /obj/item/weldingtool/largetank/cyborg,
+	items_to_create = list(/obj/item/screwdriver/cyborg, /obj/item/wrench/cyborg, /obj/item/weldingtool/largetank/cyborg,
 		/obj/item/crowbar/cyborg, /obj/item/wirecutters/cyborg, /obj/item/multitool/cyborg)
 
 /obj/item/organ/cyberimp/arm/toolset/l
@@ -257,18 +257,18 @@
 /obj/item/organ/cyberimp/arm/esword
 	name = "arm-mounted energy blade"
 	desc = "An illegal and highly dangerous cybernetic implant that can project a deadly blade of concentrated energy."
-	items_to_create = newlist(/obj/item/melee/transforming/energy/blade/hardlight)
+	items_to_create = list(/obj/item/melee/transforming/energy/blade/hardlight)
 
 /obj/item/organ/cyberimp/arm/medibeam
 	name = "integrated medical beamgun"
 	desc = "A cybernetic implant that allows the user to project a healing beam from their hand."
-	items_to_create = newlist(/obj/item/gun/medbeam)
+	items_to_create = list(/obj/item/gun/medbeam)
 
 
 /obj/item/organ/cyberimp/arm/flash
 	name = "integrated high-intensity photon projector" //Why not
 	desc = "An integrated projector mounted onto a user's arm that is able to be used as a powerful flash."
-	items_to_create = newlist(/obj/item/assembly/flash/armimplant)
+	items_to_create = list(/obj/item/assembly/flash/armimplant)
 
 /obj/item/organ/cyberimp/arm/flash/Initialize()
 	. = ..()
@@ -277,7 +277,7 @@
 		if(!istype(/obj/item/assembly/flash/armimplant, potential_flash))
 			continue
 		var/obj/item/assembly/flash/armimplant/flash = potential_flash
-		flash.I = WEAKREF(src)
+		flash.I = src
 
 /obj/item/organ/cyberimp/arm/flash/Extend()
 	. = ..()
@@ -285,18 +285,18 @@
 	active_item.set_light_on(TRUE)
 
 /obj/item/organ/cyberimp/arm/flash/Retract()
-	active_item.set_light_on(FALSE)
+	active_item?.set_light_on(FALSE)
 	return ..()
 
 /obj/item/organ/cyberimp/arm/baton
 	name = "arm electrification implant"
 	desc = "An illegal combat implant that allows the user to administer disabling shocks from their arm."
-	items_to_create = newlist(/obj/item/borg/stun)
+	items_to_create = list(/obj/item/borg/stun)
 
 /obj/item/organ/cyberimp/arm/combat
 	name = "combat cybernetics implant"
 	desc = "A powerful cybernetic implant that contains combat modules built into the user's arm."
-	items_to_create = newlist(/obj/item/melee/transforming/energy/blade/hardlight, /obj/item/gun/medbeam, /obj/item/borg/stun, /obj/item/assembly/flash/armimplant)
+	items_to_create = list(/obj/item/melee/transforming/energy/blade/hardlight, /obj/item/gun/medbeam, /obj/item/borg/stun, /obj/item/assembly/flash/armimplant)
 
 /obj/item/organ/cyberimp/arm/combat/Initialize()
 	. = ..()
@@ -305,15 +305,15 @@
 		if(!istype(/obj/item/assembly/flash/armimplant, potential_flash))
 			continue
 		var/obj/item/assembly/flash/armimplant/flash = potential_flash
-		flash.I = WEAKREF(src)
+		flash.I = src
 
 /obj/item/organ/cyberimp/arm/surgery
 	name = "surgical toolset implant"
 	desc = "A set of surgical tools hidden behind a concealed panel on the user's arm."
-	items_to_create = newlist(/obj/item/retractor/augment, /obj/item/hemostat/augment, /obj/item/cautery/augment, /obj/item/surgicaldrill/augment, /obj/item/scalpel/augment, /obj/item/circular_saw/augment)
+	items_to_create = list(/obj/item/retractor/augment, /obj/item/hemostat/augment, /obj/item/cautery/augment, /obj/item/surgicaldrill/augment, /obj/item/scalpel/augment, /obj/item/circular_saw/augment)
 
 /obj/item/organ/cyberimp/arm/power_cord
 	name = "power cord implant"
 	desc = "An internal power cord hooked up to a battery. Useful if you run on volts."
-	items_to_create = newlist(/obj/item/apc_powercord)
+	items_to_create = list(/obj/item/apc_powercord)
 	zone = "l_arm" 

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -1,3 +1,13 @@
+//Singulostation edit - Implement tg arm augment refactors
+
+/* THIS WHOLE FILE IS SIGNIFICANTLY MODIFIED. 
+ * See the following:
+ * https://github.com/tgstation/tgstation/pull/53893
+ * https://github.com/tgstation/tgstation/pull/54914
+ * https://github.com/tgstation/tgstation/pull/59242
+ * https://github.com/tgstation/tgstation/pull/59371
+ */
+
 /obj/item/organ/cyberimp/arm
 	name = "arm-mounted implant"
 	desc = "You shouldn't see this! Adminhelp and report this as an issue on github!"
@@ -267,7 +277,7 @@
 		if(!istype(/obj/item/assembly/flash/armimplant, potential_flash))
 			continue
 		var/obj/item/assembly/flash/armimplant/flash = potential_flash
-		flash.arm = WEAKREF(src)
+		flash.I = WEAKREF(src)
 
 /obj/item/organ/cyberimp/arm/flash/Extend()
 	. = ..()
@@ -295,7 +305,7 @@
 		if(!istype(/obj/item/assembly/flash/armimplant, potential_flash))
 			continue
 		var/obj/item/assembly/flash/armimplant/flash = potential_flash
-		flash.arm = WEAKREF(src)
+		flash.I = WEAKREF(src)
 
 /obj/item/organ/cyberimp/arm/surgery
 	name = "surgical toolset implant"

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -5,18 +5,17 @@
 	icon_state = "implant-toolkit"
 	w_class = WEIGHT_CLASS_SMALL
 	actions_types = list(/datum/action/item_action/organ_action/toggle)
-
-	var/list/items_list = list()
-	// Used to store a list of all items inside, for multi-item implants.
-	// I would use contents, but they shuffle on every activation/deactivation leading to interface inconsistencies.
-
-	var/obj/item/holder = null
-	// You can use this var for item path, it would be converted into an item on New()
+	///A ref for the arm we're taking up. Mostly for the unregister signal upon removal
+	var/obj/hand
+	/// Used to store a list of all items inside, for multi-item implants.
+	var/list/items_list = list()// I would use contents, but they shuffle on every activation/deactivation leading to interface inconsistencies.
+	/// You can use this var for item path, it would be converted into an item on New().
+	var/obj/item/active_item
 
 /obj/item/organ/cyberimp/arm/Initialize()
 	. = ..()
-	if(ispath(holder))
-		holder = new holder(src)
+	if(ispath(active_item))
+		active_item = new active_item(src)
 
 	update_icon()
 	SetSlotFromZone()
@@ -54,8 +53,17 @@
 	to_chat(user, "<span class='notice'>You modify [src] to be installed on the [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>")
 	update_icon()
 
+/obj/item/organ/cyberimp/arm/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = TRUE)
+	. = ..()
+	var/side = zone == BODY_ZONE_R_ARM? RIGHT_HANDS : LEFT_HANDS
+	hand = owner.hand_bodyparts[side]
+	if(hand)
+		RegisterSignal(hand, COMSIG_ITEM_ATTACK_SELF, .proc/ui_action_click) //If the limb gets an attack-self, open the menu. Only happens when hand is empty
+
 /obj/item/organ/cyberimp/arm/Remove(mob/living/carbon/M, special = 0)
 	Retract()
+	if(hand)
+		UnregisterSignal(hand, COMSIG_ITEM_ATTACK_SELF)
 	..()
 
 /obj/item/organ/cyberimp/arm/emp_act(severity)
@@ -68,40 +76,33 @@
 		Retract()
 
 /obj/item/organ/cyberimp/arm/proc/Retract()
-	if(!holder || (holder in src))
+	if(!active_item || (active_item in src))
 		return
 
-	owner.visible_message("<span class='notice'>[owner] retracts [holder] back into [owner.p_their()] [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
-		"<span class='notice'>[holder] snaps back into your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
+	owner.visible_message("<span class='notice'>[owner] retracts [active_item] back into [owner.p_their()] [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
+		"<span class='notice'>[active_item] snaps back into your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
 		"<span class='hear'>You hear a short mechanical noise.</span>")
 
-	if(istype(holder, /obj/item/assembly/flash/armimplant))
-		var/obj/item/assembly/flash/F = holder
-		F.set_light(0)
-
-	owner.transferItemToLoc(holder, src, TRUE)
-	holder = null
+	owner.transferItemToLoc(active_item, src, TRUE)
+	UnregisterSignal(active_item, COMSIG_ITEM_DROPPED)
+	active_item = null
 	playsound(get_turf(owner), 'sound/mecha/mechmove03.ogg', 50, TRUE)
 
 /obj/item/organ/cyberimp/arm/proc/Extend(var/obj/item/item)
 	if(!(item in src))
 		return
 
-	holder = item
+	active_item = item
+	RegisterSignal(active_item, COMSIG_ITEM_DROPPED, .proc/Retract) //Drop it to put away.
 
-	ADD_TRAIT(holder, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
-	holder.resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	holder.slot_flags = null
-	holder.set_custom_materials(null)
-
-	if(istype(holder, /obj/item/assembly/flash/armimplant))
-		var/obj/item/assembly/flash/F = holder
-		F.set_light(7)
+	active_item.resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	active_item.slot_flags = null
+	active_item.set_custom_materials(null)
 
 	var/side = zone == BODY_ZONE_R_ARM? RIGHT_HANDS : LEFT_HANDS
 	var/hand = owner.get_empty_held_index_for_side(side)
 	if(hand)
-		owner.put_in_hand(holder, hand)
+		owner.put_in_hand(active_item, hand)
 	else
 		var/list/hand_items = owner.get_held_items_for_side(side, all = TRUE)
 		var/success = FALSE
@@ -112,24 +113,24 @@
 				failure_message += "<span class='warning'>Your [I] interferes with [src]!</span>"
 				continue
 			to_chat(owner, "<span class='notice'>You drop [I] to activate [src]!</span>")
-			success = owner.put_in_hand(holder, owner.get_empty_held_index_for_side(side))
+			success = owner.put_in_hand(active_item, owner.get_empty_held_index_for_side(side))
 			break
 		if(!success)
 			for(var/i in failure_message)
 				to_chat(owner, i)
 			return
-	owner.visible_message("<span class='notice'>[owner] extends [holder] from [owner.p_their()] [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
-		"<span class='notice'>You extend [holder] from your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
+	owner.visible_message("<span class='notice'>[owner] extends [active_item] from [owner.p_their()] [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
+		"<span class='notice'>You extend [active_item] from your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
 		"<span class='hear'>You hear a short mechanical noise.</span>")
 	playsound(get_turf(owner), 'sound/mecha/mechmove03.ogg', 50, TRUE)
 
 /obj/item/organ/cyberimp/arm/ui_action_click()
-	if((organ_flags & ORGAN_FAILING) || (!holder && !contents.len))
+	if((organ_flags & ORGAN_FAILING) || (!active_item && !contents.len))
 		to_chat(owner, "<span class='warning'>The implant doesn't respond. It seems to be broken...</span>")
 		return
 
-	if(!holder || (holder in src))
-		holder = null
+	if(!active_item || (active_item in src))
+		active_item = null
 		if(contents.len == 1)
 			Extend(contents[1])
 		else
@@ -137,7 +138,7 @@
 			for(var/obj/item/I in items_list)
 				choice_list[I] = image(I)
 			var/obj/item/choice = show_radial_menu(owner, owner, choice_list)
-			if(owner && owner == usr && owner.stat != DEAD && (src in owner.internal_organs) && !holder && (choice in contents))
+			if(owner && owner == usr && owner.stat != DEAD && (src in owner.internal_organs) && !active_item && (choice in contents))
 				// This monster sanity check is a nice example of how bad input is.
 				Extend(choice)
 	else
@@ -168,6 +169,11 @@
 /obj/item/organ/cyberimp/arm/gun/laser/l
 	zone = BODY_ZONE_L_ARM
 
+/obj/item/organ/cyberimp/arm/gun/laser/Initialize()
+	. = ..()
+	var/obj/item/organ/cyberimp/arm/gun/laser/laserphasergun = locate(/obj/item/gun/energy/laser/mounted) in contents
+	laserphasergun.icon = icon //No invisible laser guns kthx
+	laserphasergun.icon_state = icon_state
 
 /obj/item/organ/cyberimp/arm/gun/taser
 	name = "arm-mounted taser implant"
@@ -215,6 +221,15 @@
 	if(locate(/obj/item/assembly/flash/armimplant) in items_list)
 		var/obj/item/assembly/flash/armimplant/F = locate(/obj/item/assembly/flash/armimplant) in items_list
 		F.I = src
+
+/obj/item/organ/cyberimp/arm/flash/Extend()
+	. = ..()
+	active_item.set_light_range(7)
+	active_item.set_light_on(TRUE)
+
+/obj/item/organ/cyberimp/arm/flash/Retract()
+	active_item.set_light_on(FALSE)
+	return ..()
 
 /obj/item/organ/cyberimp/arm/baton
 	name = "arm electrification implant"

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -7,6 +7,8 @@
 	actions_types = list(/datum/action/item_action/organ_action/toggle)
 	///A ref for the arm we're taking up. Mostly for the unregister signal upon removal
 	var/obj/hand
+	//A list of typepaths to create and insert into ourself on init
+	var/list/items_to_create = list()
 	/// Used to store a list of all items inside, for multi-item implants.
 	var/list/items_list = list()// I would use contents, but they shuffle on every activation/deactivation leading to interface inconsistencies.
 	/// You can use this var for item path, it would be converted into an item on New().
@@ -16,10 +18,26 @@
 	. = ..()
 	if(ispath(active_item))
 		active_item = new active_item(src)
+		items_list += WEAKREF(active_item)
+
+	for(var/typepath in items_to_create)
+		var/atom/new_item = new typepath(src)
+		items_list += WEAKREF(new_item)
 
 	update_icon()
 	SetSlotFromZone()
 	items_list = contents.Copy()
+
+/obj/item/organ/cyberimp/arm/Destroy()
+	hand = null
+	active_item = null
+	for(var/datum/weakref/ref in items_list)
+		var/obj/item/to_del = ref.resolve()
+		if(!to_del)
+			continue
+		qdel(to_del)
+	items_list.Cut()
+	return ..()
 
 /obj/item/organ/cyberimp/arm/proc/SetSlotFromZone()
 	switch(zone)
@@ -155,8 +173,11 @@
 			Extend(contents[1])
 		else
 			var/list/choice_list = list()
-			for(var/obj/item/I in items_list)
-				choice_list[I] = image(I)
+			for(var/datum/weakref/augment_ref in items_list)
+				var/obj/item/augment_item = augment_ref.resolve()
+				if(!augment_item)
+					items_list -= augment_ref
+					continue
 			var/obj/item/choice = show_radial_menu(owner, owner, choice_list)
 			if(owner && owner == usr && owner.stat != DEAD && (src in owner.internal_organs) && !active_item && (choice in contents))
 				// This monster sanity check is a nice example of how bad input is.
@@ -184,7 +205,7 @@
 	name = "arm-mounted laser implant"
 	desc = "A variant of the arm cannon implant that fires lethal laser beams. The cannon emerges from the subject's arm and remains inside when not in use."
 	icon_state = "arm_laser"
-	contents = newlist(/obj/item/gun/energy/laser/mounted)
+	items_to_create = newlist(/obj/item/gun/energy/laser/mounted)
 
 /obj/item/organ/cyberimp/arm/gun/laser/l
 	zone = BODY_ZONE_L_ARM
@@ -199,7 +220,7 @@
 	name = "arm-mounted taser implant"
 	desc = "A variant of the arm cannon implant that fires electrodes and disabler shots. The cannon emerges from the subject's arm and remains inside when not in use."
 	icon_state = "arm_taser"
-	contents = newlist(/obj/item/gun/energy/e_gun/advtaser/mounted)
+	items_to_create = newlist(/obj/item/gun/energy/e_gun/advtaser/mounted)
 
 /obj/item/organ/cyberimp/arm/gun/taser/l
 	zone = BODY_ZONE_L_ARM
@@ -207,40 +228,46 @@
 /obj/item/organ/cyberimp/arm/toolset
 	name = "integrated toolset implant"
 	desc = "A stripped-down version of the engineering cyborg toolset, designed to be installed on subject's arm. Contain advanced versions of every tool."
-	contents = newlist(/obj/item/screwdriver/cyborg, /obj/item/wrench/cyborg, /obj/item/weldingtool/largetank/cyborg,
+	items_to_create = newlist(/obj/item/screwdriver/cyborg, /obj/item/wrench/cyborg, /obj/item/weldingtool/largetank/cyborg,
 		/obj/item/crowbar/cyborg, /obj/item/wirecutters/cyborg, /obj/item/multitool/cyborg)
 
 /obj/item/organ/cyberimp/arm/toolset/l
 	zone = BODY_ZONE_L_ARM
 
 /obj/item/organ/cyberimp/arm/toolset/emag_act(mob/user)
-	if(!(locate(/obj/item/kitchen/knife/combat/cyborg) in items_list))
-		to_chat(user, "<span class='notice'>You unlock [src]'s integrated knife!</span>")
-		items_list += new /obj/item/kitchen/knife/combat/cyborg(src)
-		return 1
-	return 0
+	for(var/datum/weakref/created_item in items_list)
+		var/obj/potential_knife = created_item.resolve()
+		if(istype(/obj/item/kitchen/knife/combat/cyborg, potential_knife))
+			return FALSE
+
+	to_chat(user, "<span class='notice'>You unlock [src]'s integrated knife!</span>")
+	items_list += WEAKREF(new /obj/item/kitchen/knife/combat/cyborg(src))
+	return TRUE
 
 /obj/item/organ/cyberimp/arm/esword
 	name = "arm-mounted energy blade"
 	desc = "An illegal and highly dangerous cybernetic implant that can project a deadly blade of concentrated energy."
-	contents = newlist(/obj/item/melee/transforming/energy/blade/hardlight)
+	items_to_create = newlist(/obj/item/melee/transforming/energy/blade/hardlight)
 
 /obj/item/organ/cyberimp/arm/medibeam
 	name = "integrated medical beamgun"
 	desc = "A cybernetic implant that allows the user to project a healing beam from their hand."
-	contents = newlist(/obj/item/gun/medbeam)
+	items_to_create = newlist(/obj/item/gun/medbeam)
 
 
 /obj/item/organ/cyberimp/arm/flash
 	name = "integrated high-intensity photon projector" //Why not
 	desc = "An integrated projector mounted onto a user's arm that is able to be used as a powerful flash."
-	contents = newlist(/obj/item/assembly/flash/armimplant)
+	items_to_create = newlist(/obj/item/assembly/flash/armimplant)
 
 /obj/item/organ/cyberimp/arm/flash/Initialize()
 	. = ..()
-	if(locate(/obj/item/assembly/flash/armimplant) in items_list)
-		var/obj/item/assembly/flash/armimplant/F = locate(/obj/item/assembly/flash/armimplant) in items_list
-		F.I = src
+	for(var/datum/weakref/created_item in items_list)
+		var/obj/potential_flash = created_item.resolve()
+		if(!istype(/obj/item/assembly/flash/armimplant, potential_flash))
+			continue
+		var/obj/item/assembly/flash/armimplant/flash = potential_flash
+		flash.arm = WEAKREF(src)
 
 /obj/item/organ/cyberimp/arm/flash/Extend()
 	. = ..()
@@ -254,26 +281,29 @@
 /obj/item/organ/cyberimp/arm/baton
 	name = "arm electrification implant"
 	desc = "An illegal combat implant that allows the user to administer disabling shocks from their arm."
-	contents = newlist(/obj/item/borg/stun)
+	items_to_create = newlist(/obj/item/borg/stun)
 
 /obj/item/organ/cyberimp/arm/combat
 	name = "combat cybernetics implant"
 	desc = "A powerful cybernetic implant that contains combat modules built into the user's arm."
-	contents = newlist(/obj/item/melee/transforming/energy/blade/hardlight, /obj/item/gun/medbeam, /obj/item/borg/stun, /obj/item/assembly/flash/armimplant)
+	items_to_create = newlist(/obj/item/melee/transforming/energy/blade/hardlight, /obj/item/gun/medbeam, /obj/item/borg/stun, /obj/item/assembly/flash/armimplant)
 
 /obj/item/organ/cyberimp/arm/combat/Initialize()
 	. = ..()
-	if(locate(/obj/item/assembly/flash/armimplant) in items_list)
-		var/obj/item/assembly/flash/armimplant/F = locate(/obj/item/assembly/flash/armimplant) in items_list
-		F.I = src
+	for(var/datum/weakref/created_item in items_list)
+		var/obj/potential_flash = created_item.resolve()
+		if(!istype(/obj/item/assembly/flash/armimplant, potential_flash))
+			continue
+		var/obj/item/assembly/flash/armimplant/flash = potential_flash
+		flash.arm = WEAKREF(src)
 
 /obj/item/organ/cyberimp/arm/surgery
 	name = "surgical toolset implant"
 	desc = "A set of surgical tools hidden behind a concealed panel on the user's arm."
-	contents = newlist(/obj/item/retractor/augment, /obj/item/hemostat/augment, /obj/item/cautery/augment, /obj/item/surgicaldrill/augment, /obj/item/scalpel/augment, /obj/item/circular_saw/augment)
+	items_to_create = newlist(/obj/item/retractor/augment, /obj/item/hemostat/augment, /obj/item/cautery/augment, /obj/item/surgicaldrill/augment, /obj/item/scalpel/augment, /obj/item/circular_saw/augment)
 
 /obj/item/organ/cyberimp/arm/power_cord
 	name = "power cord implant"
 	desc = "An internal power cord hooked up to a battery. Useful if you run on volts."
-	contents = newlist(/obj/item/apc_powercord)
+	items_to_create = newlist(/obj/item/apc_powercord)
 	zone = "l_arm" 

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -58,7 +58,7 @@
 	var/side = zone == BODY_ZONE_R_ARM? RIGHT_HANDS : LEFT_HANDS
 	hand = owner.hand_bodyparts[side]
 	if(hand)
-		RegisterSignal(hand, COMSIG_ITEM_ATTACK_SELF, .proc/ui_action_click) //If the limb gets an attack-self, open the menu. Only happens when hand is empty
+		RegisterSignal(hand, COMSIG_ITEM_ATTACK_SELF, .proc/on_item_attack_self) //If the limb gets an attack-self, open the menu. Only happens when hand is empty
 		RegisterSignal(M, COMSIG_KB_MOB_DROPITEM_DOWN, .proc/dropkey) //We're nodrop, but we'll watch for the drop hotkey anyway and then stow if possible.
 
 /obj/item/organ/cyberimp/arm/Remove(mob/living/carbon/M, special = 0)
@@ -67,6 +67,10 @@
 		UnregisterSignal(hand, COMSIG_ITEM_ATTACK_SELF)
 		UnregisterSignal(M, COMSIG_KB_MOB_DROPITEM_DOWN)
 	..()
+
+/obj/item/organ/cyberimp/arm/proc/on_item_attack_self()
+	SIGNAL_HANDLER
+	INVOKE_ASYNC(src, .proc/ui_action_click)
 
 /obj/item/organ/cyberimp/arm/emp_act(severity)
 	. = ..()
@@ -85,6 +89,7 @@
   * selected, and that the item is actually owned by us, and then we'll hand off the rest to Retract()
 **/
 /obj/item/organ/cyberimp/arm/proc/dropkey(mob/living/carbon/host)
+	SIGNAL_HANDLER
 	if(!host)
 		return //How did we even get here
 	if(hand != host.hand_bodyparts[host.active_hand_index])

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -121,7 +121,8 @@
 		return //How did we even get here
 	if(hand != host.hand_bodyparts[host.active_hand_index])
 		return //wrong hand
-	Retract()
+	if(Retract())
+		return COMSIG_KB_ACTIVATED //Suppress the dropping since the item is gone and it would act like dropping with empty hand
 
 /obj/item/organ/cyberimp/arm/proc/Retract()
 	if(!active_item || (active_item in src))
@@ -134,6 +135,8 @@
 	owner.transferItemToLoc(active_item, src, TRUE)
 	active_item = null
 	playsound(get_turf(owner), 'sound/mecha/mechmove03.ogg', 50, TRUE)
+
+	return TRUE //Signal a successful retraction
 
 /obj/item/organ/cyberimp/arm/proc/Extend(var/obj/item/item)
 	if(!(item in src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the following PRs:
- https://github.com/tgstation/tgstation/pull/53893
- https://github.com/tgstation/tgstation/pull/54914
- https://github.com/tgstation/tgstation/pull/59242
  - Only ported changes to augments_arms.dm
- https://github.com/tgstation/tgstation/pull/59371
  - Only ported changes to augments_arms.dm

Features reworks in terms of code, but more importantly, adds the ability to open an augment (for example integrated toolset) by pressing Z with an empty hand on an arm with an augment, as well as the ability to retract an augment by dropping while holding an augment item.

**NOTE:** The changes in augments_arms.dm have not been documented individually. The changes apply to almost every augment, if not every augment. For this reason, a comment has been put at the top of the file instead.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes augments much more usable, without either placing the buttons in a way that obscures the game or doing many very repetitive hand movements across to the buttons every time you need to change the tool.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now use the Activate Held Object and Drop Object hotkeys (default Z and Q, respectively) to activate arm-implanted tools and put objects away. You must have the hand free before you can activate it this way.
balance: Arm implant tools are no longer no-drop, and instead simply snap back if they get dropped. Don't sweat it, if you slip just press Z again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
