### PR TITLE
Make conveyor switches togglable between one-way and two-way

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -331,6 +331,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(I.tool_behaviour == TOOL_CROWBAR)
 		var/obj/item/conveyor_switch_construct/C = new/obj/item/conveyor_switch_construct(src.loc)
 		C.id = id
+		C.oneway = oneway //Singulostation edit - Buildable one-way conveyors
 		transfer_fingerprints_to(C)
 		to_chat(user, "<span class='notice'>You detach the conveyor switch.</span>")
 		qdel(src)
@@ -356,6 +357,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	w_class = WEIGHT_CLASS_BULKY
 	custom_materials = list(/datum/material/iron = 450, /datum/material/glass = 190) // WS Edit - Item Materials
 	var/id = "" //inherited by the switch
+	var/oneway = FALSE //Singulostation edit - Buildable one-way conveyors
 
 /obj/item/conveyor_switch_construct/Initialize()
 	. = ..()
@@ -379,8 +381,25 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		to_chat(user, "[icon2html(src, user)]<span class=notice>The conveyor switch did not detect any linked conveyor belts in range.</span>")
 		return
 	var/obj/machinery/conveyor_switch/NC = new/obj/machinery/conveyor_switch(A, id)
+	NC.oneway = oneway //Singulostation edit - Buildable one-way conveyors
 	transfer_fingerprints_to(NC)
 	qdel(src)
+
+//Singulostation begin - Buildable one-way conveyors
+/obj/item/conveyor_switch_construct/attackby(obj/item/I, mob/user, params)
+	if(I.tool_behaviour == TOOL_SCREWDRIVER)
+		oneway = !oneway
+		to_chat(user, "<span class=notice>You switch [src] to its [oneway ? "one-way" : "two-way"] configuration.</span>")
+		return TRUE
+
+	return ..()
+
+/obj/item/conveyor_switch_construct/examine(mob/user)
+	. = ..()
+
+	if(oneway)
+		. += "[src] is locked to one direction only."
+//Singulostation end
 
 /obj/item/stack/conveyor
 	name = "conveyor belt assembly"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Conveyor switch items now store `oneway` state. The state persists when the switch is turned into item and placed back down.
You can toggle this state between `FALSE` and `TRUE` with a screwdriver.

## Why It's Good For The Game

One-way conveyors make it possible to foolproof systems to prevent undesirable behavior when the conveyor is set to the wrong direction.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Conveyor switches can be toggled between two-way and one-way with a screwdriver when in item form
add: Conveyor switches remember their one-way state when turned into item form
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
