### PR TITLE
Fix turbine runtime and RPM gain when intake is solid turf

### DIFF
--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -131,14 +131,17 @@
 		return
 	cut_overlays()
 
-	rpm = 0.9* rpm + 0.1 * rpmtarget
-	var/datum/gas_mixture/environment = inturf.return_air()
+	//Singulostation begin - fix wall turbines
+	if(istype(inturf, /turf/open))
+		rpm = 0.9* rpm + 0.1 * rpmtarget
+		var/datum/gas_mixture/environment = inturf.return_air()
 
-	// It's a simplified version taking only 1/10 of the moles from the turf nearby. It should be later changed into a better version
+		// It's a simplified version taking only 1/10 of the moles from the turf nearby. It should be later changed into a better version
 
-	var/transfer_moles = environment.total_moles()/10
-	var/datum/gas_mixture/removed = inturf.remove_air(transfer_moles)
-	gas_contained.merge(removed)
+		var/transfer_moles = environment.total_moles()/10
+		var/datum/gas_mixture/removed = inturf.remove_air(transfer_moles)
+		gas_contained.merge(removed)
+	//Singulostation end - fix wall turbines
 
 // RPM function to include compression friction - be advised that too low/high of a compfriction value can make things screwy
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The turbine can be glitched by placing the wall on the intake turf, because it assumes the turf has atmos. Because of this it runtimes halfway through the process, which is presumably what causes it to start generating a lot more RPM which leads to it generating a lot more power.

This PR makes it only try to interact with the intake turf atmos if it's an open turf.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes a bug, and lots of runtimes when the bug is being utilised.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Turbines no longer produce ridiculous power and throw tons of runtimes when the intake is a wall
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
