### PR TITLE
Walking no longer makes you trip

### DIFF
--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -30,7 +30,7 @@
 			adjust_nutrition(-(HUNGER_FACTOR/10))
 			if(m_intent == MOVE_INTENT_RUN)
 				adjust_nutrition(-(HUNGER_FACTOR/10))
-		if(body_position == STANDING_UP) //singulo start - Tripping
+		if(body_position == STANDING_UP && m_intent == MOVE_INTENT_RUN) //singulo start - Tripping
 			var/trip_chance
 			var/turf/T = get_turf(NewLoc)
 			for(var/obj/item/I in T.contents)


### PR DESCRIPTION
## About The Pull Request

Makes it impossible to trip if you're walking, you can imagine this as carefully watching you step and placing your feet in order to not trip.

## Why It's Good For The Game

Sometimes it's inevitable that you'll have a lot of items on a turf (think butchering mobs, unloading backpacks or toolbelts, taking off your hardsuit, etc.) and there needs to be a way to avoid tripping, at the cost of speed.

## Changelog
:cl:
tweak: You can now carefully walk over piles of items to avoid tripping over them.
/:cl: