### PR TITLE
Fix tripping over intercoms

### DIFF
--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -37,7 +37,7 @@
 			var/trip_chance
 			var/turf/T = get_turf(NewLoc)
 			for(var/obj/item/I in T.contents)
-				if(trip_blacklist[I.type])
+				if(is_type_in_typecache(I, trip_blacklist))
 					continue
 				trip_chance += (I.w_class/4)-0.25
 			if(prob(20*log(trip_chance+0.5)))

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -37,6 +37,8 @@
 			var/trip_chance
 			var/turf/T = get_turf(NewLoc)
 			for(var/obj/item/I in T.contents)
+				if(I.invisibility > SEE_INVISIBLE_LIVING)
+					continue // Stop tripping over invisible things, like things under the floortiles
 				if(is_type_in_typecache(I, trip_blacklist))
 					continue
 				trip_chance += (I.w_class/4)-0.25

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -22,6 +22,9 @@
 		return TRUE
 
 /mob/living/carbon/Move(NewLoc, direct)
+	var/static/trip_blacklist = typecacheof(list( //singulo start - Tripping
+		/obj/item/radio/intercom
+		)) //singulo end - Tripping
 	. = ..()
 	if(. && !(movement_type & FLOATING)) //floating is easy
 		if(HAS_TRAIT(src, TRAIT_NOHUNGER))
@@ -34,6 +37,8 @@
 			var/trip_chance
 			var/turf/T = get_turf(NewLoc)
 			for(var/obj/item/I in T.contents)
+				if(trip_blacklist[I.type])
+					continue
 				trip_chance += (I.w_class/4)-0.25
 			if(prob(20*log(trip_chance+0.5)))
 				Knockdown(3 SECONDS)


### PR DESCRIPTION
## About The Pull Request

Fixes tripping over intercoms since they're a subtype of `/obj/item` to inherit station-bounced radio function

## Changelog
:cl:
fix: You can no longer trip over station intercoms.
/:cl: