### PR TITLE
Prevents shenanigans with dusting mobs

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -285,6 +285,16 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Trait associated to lacking electrical power.
 #define POWER_LACK_TRAIT "power-lack"
 
+// SinguloStation 13 traits begin
+// This place is for trait defines that are used in edits of upstream code.
+// Why? Because files are included in tgstation.dme in alphabetical order
+// so singulo/__DEFINES comes after all tg files (but before whitesands files)
+
+// We're currently going through dust()
+#define TRAIT_DUSTING	"dusting"
+
+// SinguloStation 13 traits end
+
 // unique trait sources, still defines
 #define CLONING_POD_TRAIT "cloning-pod"
 #define STATUE_MUTE "statue"

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -27,7 +27,14 @@
 	return
 
 /mob/living/dust(just_ash, drop_items, force)
-	Stun(100, ignore_canstun=TRUE) // Singulo edit - Dust animation
+	// Singulo edit begin - Dust animation
+	if(HAS_TRAIT(src, TRAIT_DUSTING))
+		return
+	Stun(100, ignore_canstun=TRUE)
+	anchored = TRUE
+	density = FALSE
+	ADD_TRAIT(src, TRAIT_DUSTING, "living_dust")
+	// Singulo end - Dust animation
 
 	if(drop_items)
 		unequip_everything()
@@ -42,8 +49,8 @@
 /mob/living/proc/dust_animation() //Singulo edit - Dust animation
 	var/icon/I = new(icon)
 	if(I.Width() > 32 || I.Height() > 32)
-		return 0;
-	var/obj/effect/displacement/D = new /obj/effect/displacement/dust/(loc, src)
+		return 5
+	var/obj/effect/abstract/displacement/dust/D = new(loc, src)
 	return D.duration
 
 /mob/living/proc/spawn_dust(just_ash = FALSE)

--- a/singulostation/code/game/objects/effects/displacement.dm
+++ b/singulostation/code/game/objects/effects/displacement.dm
@@ -1,4 +1,4 @@
-/obj/effect/displacement
+/obj/effect/abstract/displacement
 	icon = 'singulostation/icons/effects/displacements.dmi'
 	icon_state = "none"
 	anchored = TRUE
@@ -9,7 +9,7 @@
 	var/rt_name
 	var/atom/movable/parent
 
-/obj/effect/displacement/Initialize(mapload, atom/movable/AM)
+/obj/effect/abstract/displacement/Initialize(mapload, atom/movable/AM)
 	. = ..()
 	parent = AM
 	rt_name = "[alias][ref(src)]"
@@ -18,23 +18,14 @@
 	if(duration)
 		timerid = QDEL_IN(src, duration)
 
-/obj/effect/displacement/Destroy()
+/obj/effect/abstract/displacement/Destroy()
 	. = ..()
 	if(!QDELETED(parent))
 		parent.remove_filter(rt_name)
 	if(timerid)
 		deltimer(timerid)
 
-/obj/effect/displacement/singularity_act()
-	return
-
-/obj/effect/displacement/singularity_pull()
-	return
-
-/obj/effect/displacement/ex_act()
-	return
-
-/obj/effect/displacement/dust
+/obj/effect/abstract/displacement/dust
 	icon_state = "dust"
 	alias = "*dust_rt"
 	duration = 14


### PR DESCRIPTION
## About The Pull Request

This makes dusting anchor the mob, make it possible to walk through it and gives it a trait to stop it from being dusted more than once at a time

## Why It's Good For The Game

Hopefully fixes an issue with hivelords dusting like mad every tick by being pushed into it

## Changelog
:cl:
fix: Dusting mobs should be more predictable now.
/:cl: