### PR TITLE
Update blood.dm

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -15,7 +15,7 @@
 	bleedsuppress = 0
 	if(stat != DEAD && bleed_rate)
 		to_chat(src, "<span class='warning'>The blood soaks through your bandage.</span>")
-
+	visible_message("<span class='warning'>[src.name]'s bandage falls off.</span>", ignored_mobs = list(src)) // Singulo edit - visible emote when someones bandage ends and falls off
 
 /mob/living/carbon/monkey/handle_blood()
 	if(bodytemperature >= TCRYO && !(HAS_TRAIT(src, TRAIT_HUSK))) //cryosleep or husked people do not pump the blood.


### PR DESCRIPTION
visible emote when someones bandage ends and falls off

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

visible emote when someones bandage ends and falls off

## Why It's Good For The Game

User-friendly

## Changelog
:cl:
add: visible emote when someones bandage ends and falls off
/:cl:
