### PR TITLE
Balance cloaks

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -32,7 +32,7 @@
 
 /datum/component/storage/concrete/pockets/exo/cloak
 	max_items = 1
-	max_w_class = WEIGHT_CLASS_NORMAL
+	max_w_class = WEIGHT_CLASS_SMALL // Singulostation edit - Changed WEIGHT_CLASS_NORMAL to WEIGHT_CLASS_SMALL
 	quickdraw = TRUE
 
 /datum/component/storage/concrete/pockets/exo/large


### PR DESCRIPTION
## About The Pull Request

Changes WEIGHT_CLASS_NORMAL to WEIGHT_CLASS_SMALL for balancing purposes

## Why It's Good For The Game

Much like the trashbag of holding patch, this patch is meant to balance the game, so you can't hide laser rifles and such in a cloak, but rather only small items. The cloaks are still superior to other cloaks/neckwear in the sense that it can hold _all_ small items, as opposed to specific small items (like the drake cloak that can hold mining equipment)

## Changelog
:cl:
balance: rebalanced skill-cloaks storage
/:cl:
