### PR TITLE
Void thruster

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1015,7 +1015,7 @@
 	prereq_ids = list("biotech","engineering")
 	boost_item_paths = list(/obj/item/gun/energy/alien, /obj/item/scalpel/alien, /obj/item/hemostat/alien, /obj/item/retractor/alien, /obj/item/circular_saw/alien,
 	/obj/item/cautery/alien, /obj/item/surgicaldrill/alien, /obj/item/screwdriver/abductor, /obj/item/wrench/abductor, /obj/item/crowbar/abductor, /obj/item/multitool/abductor,
-	/obj/item/weldingtool/abductor, /obj/item/wirecutters/abductor, /obj/item/circuitboard/machine/abductor, /obj/item/melee/baton/abductor, /obj/item/abductor, /obj/item/gun/energy/shrink_ray)
+	/obj/item/weldingtool/abductor, /obj/item/wirecutters/abductor, /obj/item/circuitboard/machine/abductor, /obj/item/melee/baton/abductor, /obj/item/abductor, /obj/item/gun/energy/shrink_ray, /obj/item/circuitboard/machine/shuttle/engine/void) // Singulostation edit - added /obj/item/circuitboard/machine/shuttle/engine/void (Void thrusters)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 20000
 	hidden = TRUE

--- a/whitesands/code/game/machinery/shuttle/shuttle_engine_types.dm
+++ b/whitesands/code/game/machinery/shuttle/shuttle_engine_types.dm
@@ -204,7 +204,7 @@
 
 /**
   * ### Void Engines
-  * These engines are literally magic. Requires no fuel.
+  * These engines are literally magic. Requires no fuel. //Singulostation edit - Changed description (I know this is already commented)
   */
 /obj/machinery/power/shuttle/engine/void
 	name = "void thruster"

--- a/whitesands/code/game/machinery/shuttle/shuttle_engine_types.dm
+++ b/whitesands/code/game/machinery/shuttle/shuttle_engine_types.dm
@@ -204,7 +204,7 @@
 
 /**
   * ### Void Engines
-  * These engines are literally magic. Adminspawn only.
+  * These engines are literally magic. Requires no fuel.
   */
 /obj/machinery/power/shuttle/engine/void
 	name = "void thruster"

--- a/whitesands/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/whitesands/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -82,12 +82,14 @@
 	req_components = list(/obj/item/reagent_containers/glass/beaker = 4,
 		/obj/item/stock_parts/micro_laser = 2)
 
+//Singulostation edit start - Made void thrusters *much* more expensive, as a way to balance.
 /obj/item/circuitboard/machine/shuttle/engine/void
 	name = "Void Thruster (Machine Board)"
 	build_path = /obj/machinery/power/shuttle/engine/void
-	req_components = list(/obj/item/stock_parts/capacitor/quadratic = 2,
-		/obj/item/stack/cable_coil = 5,
-		/obj/item/stock_parts/micro_laser/quadultra = 1)
+	req_components = list(/obj/item/stock_parts/capacitor/quadratic = 40,
+		/obj/item/stack/cable_coil = 25,
+		/obj/item/stock_parts/micro_laser/quadultra = 20)
+//Singulostation edit end
 
 /obj/item/circuitboard/machine/shuttle/heater
 	name = "Fueled Engine Heater (Machine Board)"


### PR DESCRIPTION

## About The Pull Request

Adds back void thrusters and makes them very expensive to make, and very tedious if you want to make many.

## Why It's Good For The Game

If you can find alien tech, then you should realistically be able to get all the alien tech, including the "magic" thrusters. Because, at that point, you've already built a shuttle and used it to, probably, go through a lot of POI (Points of Interest), and finally stumbled upon alien tech. Also, balanced them.

## Changelog
:cl:
add: Added back Void Thrusters
balance: Made Void Thrusters more expensive
/:cl:
