### PR TITLE
Fix spawn areas for anomalies

### DIFF
--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -2,7 +2,7 @@
 /datum/round_event_control/stray_cargo
 	name = "Stray Cargo Pod"
 	typepath = /datum/round_event/stray_cargo
-	weight = 20
+	weight = 6 //Singulostation edit - Changed spawn-chance from 20 to 6
 	max_occurrences = 99999 // Singulostation edit - Buffed max occurences because perma server
 	earliest_start = 300 MINUTES // Singulostation edit - Annoying round-start
 
@@ -82,7 +82,7 @@
 /datum/round_event_control/stray_cargo/syndicate
 	name = "Stray Syndicate Cargo Pod"
 	typepath = /datum/round_event/stray_cargo/syndicate
-	weight = 6
+	weight = 3 //Singulostation edit - Changed spawn-chance from 6 to 3
 	max_occurrences = 99999 // Singulostation edit - Buffed max occurences because perma server
 	earliest_start = 300 MINUTES // Singulostation edit - Annoying round-start
 

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -3,8 +3,8 @@
 	name = "Stray Cargo Pod"
 	typepath = /datum/round_event/stray_cargo
 	weight = 20
-	max_occurrences = 4
-	earliest_start = 10 MINUTES
+	max_occurrences = 99999 // Singulostation edit - Buffed max occurences because perma server
+	earliest_start = 300 MINUTES // Singulostation edit - Annoying round-start
 
 ///Spawns a cargo pod containing a random cargo supply pack on a random area of the station
 /datum/round_event/stray_cargo
@@ -68,10 +68,7 @@
 	if(!allowed_areas)
 		///Places that shouldn't explode
 		var/list/safe_area_types = typecacheof(list(
-		/area/ai_monitored/turret_protected/ai,
-		/area/ai_monitored/turret_protected/ai_upload,
-		/area/engine,
-		/area/shuttle)
+		/area/ //Singulostation edit - We don't want exploding pods
 		)
 
 		///Subtypes from the above that actually should explode.
@@ -86,8 +83,8 @@
 	name = "Stray Syndicate Cargo Pod"
 	typepath = /datum/round_event/stray_cargo/syndicate
 	weight = 6
-	max_occurrences = 1
-	earliest_start = 30 MINUTES
+	max_occurrences = 99999 // Singulostation edit - Buffed max occurences because perma server
+	earliest_start = 300 MINUTES // Singulostation edit - Annoying round-start
 
 /datum/round_event/stray_cargo/syndicate
 	possible_pack_types = list(/datum/supply_pack/misc/syndicate)


### PR DESCRIPTION
## About The Pull Request

Made stray cargo pods not explode (maybe), upped max occurences to 99999 (from like 10), and changed earliest chance of event from 10 minutes to 5 hours because they're annoying round-start, but very lucrative and farmable later on.

## Why It's Good For The Game

Made them (hopefully) not explode things, hindering work and potentially killing crew/blocking/destroying cryo and essential things. Also upped the spawn-cap from like 10 to 99999, so we can get more. Changed the earliest spawn-time from 10 minutes to 5 hours. Oh, and, changed spawn-chance (lowered), for obvious reasons.

## Changelog
:cl:
balance: Rebalanced Stray Cargo Pods
/:cl:
