### PR TITLE
Buffs toolbelts

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -40,7 +40,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.max_combined_w_class = 21
+	STR.max_combined_w_class = 33 // Singulostation edit, another half row of items. So instead of 7 spots, there's now 11.
 	STR.set_holdable(list(
 		/obj/item/crowbar,
 		/obj/item/screwdriver,
@@ -62,6 +62,13 @@
 		/obj/item/assembly/signaler,
 		/obj/item/lightreplacer,
 		/obj/item/construction/rcd,
+		//Singulostation edit start - Adds more tools
+		/obj/item/construction/rld/mini,
+		/obj/item/construction/plumbing,
+		/datum/component/storage/concrete/rped
+		/obj/item/airlock_painter
+		/obj/item/floor_painter
+		//Singulostation edit end
 		/obj/item/pipe_dispenser,
 		/obj/item/inducer,
 		/obj/item/plunger,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows toolbelts to carry the MRLD, plumbing constructor, RPED (bluespace), airlock painter, and floor painter.

Buffs toolbelt storage from 7 slots to 11 slots (21 weight to 33 weight)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Being on a construction server, it's important to have the ability to carry with you the tools needed. Normal SS13 rounds don't intend engineers to construct **ENTIRE** stations themselves, so the toolbelts weren't coded with the mindset of carrying all the tools we carry, and so we have to normally place all our tools in in our bag, which restricts what we can carry by a lot, making building tedious and sometimes just demotivates you from building entirely. This PR is meant to offload some of that burden, and place it on the toolbelt, and hopefully make people transition from TBOH waist-slot gaming to toolbelts, and TBOH are, overall, better, without this merge.

This PR gives 11 slots, as well, instead of 7 slots. Not enough slots to accomodate _literally_ all the tools (which would be 13-14 slots), but enough to lift the burden.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The toolbelt now fits the MRLD, plumbing constructor, RPED (bluespace), airlock painter, and floor painter.
balance: balanced the amount of slots the toolbelt can have; From an ordinary 7 slots to engineer gaming 11 slots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
