### PR TITLE
Fireproofing Potion Buff

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -934,6 +934,7 @@
 	resistance_flags = FIRE_PROOF
 	var/uses = 3
 
+//Singulostation Edit start --Made fireproofing potions work like lavaproofing potions
 /obj/item/slimepotion/fireproof/afterattack(obj/item/C, mob/user, proximity)
 	. = ..()
 	if(!proximity)
@@ -962,6 +963,7 @@
 	uses --
 	if(!uses)
 		qdel(src)
+//Singulostation Edit end
 
 /obj/item/slimepotion/genderchange
 	name = "gender change potion"

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -944,7 +944,9 @@
 	if(!istype(C))
 		to_chat(user, "<span class='warning'>You can't coat this with the fireproofing potion!</span>")
 		return
-	
+	if(C.resistance_flags == FIRE_PROOF)
+			to_chat(user, "<span class='warning'>The [C] is already fireproof!</span>")
+			return
 	if (istype(C, /obj/item/clothing))
 		if(C.max_heat_protection_temperature >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
 			to_chat(user, "<span class='warning'>The [C] is already fireproof!</span>")

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -934,7 +934,7 @@
 	resistance_flags = FIRE_PROOF
 	var/uses = 3
 
-/obj/item/slimepotion/fireproof/afterattack(obj/item/clothing/C, mob/user, proximity)
+/obj/item/slimepotion/fireproof/afterattack(obj/item/C, mob/user, proximity)
 	. = ..()
 	if(!proximity)
 		return
@@ -942,18 +942,21 @@
 		qdel(src)
 		return
 	if(!istype(C))
-		to_chat(user, "<span class='warning'>The potion can only be used on clothing!</span>")
+		to_chat(user, "<span class='warning'>You can't coat this with the fireproofing potion!</span>")
 		return
-	if(C.max_heat_protection_temperature >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
-		to_chat(user, "<span class='warning'>The [C] is already fireproof!</span>")
-		return
+	
+	if (istype(C, /obj/item/clothing))
+		if(C.max_heat_protection_temperature >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
+			to_chat(user, "<span class='warning'>The [C] is already fireproof!</span>")
+			return
+		var/obj/item/clothing/CL = C
+		C.max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
+		C.heat_protection = C.body_parts_covered
+		C.resistance_flags |= FIRE_PROOF
 	to_chat(user, "<span class='notice'>You slather the blue gunk over the [C], fireproofing it.</span>")
 	C.name = "fireproofed [C.name]"
 	C.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 	C.add_atom_colour("#000080", FIXED_COLOUR_PRIORITY)
-	C.max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	C.heat_protection = C.body_parts_covered
-	C.resistance_flags |= FIRE_PROOF
 	uses --
 	if(!uses)
 		qdel(src)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows fireproofing potions to work on all items, like the lavaproofing potion.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Because, if lavaproofing potions work like that, why not fireproofing potions? It's a great tool to fireproof important items that you don't want to lose to lavaland, like bicycles. I swear to god, I will buy 50 bicycles if this doesn't get merged. Chong needs SPEEEEED
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Allows fireproofing potions to work on other things than clothing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
