### PR TITLE
Fix autolathe runtime when using custom materials

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -464,6 +464,11 @@
 		use_power(power)
 		icon_state = "autolathe_n"
 		var/time = is_stack ? 32 : (32 * coeff * multiplier) ** 0.8
+		var/list/datum/weakref/users // Used exclusively for awards
+		if(from_build_queue)
+			users = build_queue[requested_design_id]["users"]
+		else
+			users = item_queue[requested_design_id]["users"]
 		//===Repeating mode===
 		//Remove from queue
 		if(from_build_queue)
@@ -486,11 +491,6 @@
 		//Create item and restart
 		process_completion_world_tick = world.time + time
 		total_build_time = time
-		var/list/datum/weakref/users
-		if(from_build_queue)
-			users = build_queue[requested_design_id]["users"]
-		else
-			users = item_queue[requested_design_id]["users"]
 		addtimer(CALLBACK(src, .proc/make_item, power, materials_used, custom_materials, multiplier, coeff, is_stack, users), time)
 		addtimer(CALLBACK(src, .proc/restart_process), time + 5)
 	else

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -268,12 +268,12 @@
 		if("queue_item")
 			var/design_id = params["design_id"]
 			var/amount = text2num(params["amount"])
-			add_to_queue(item_queue, design_id, amount)
+			add_to_queue(item_queue, design_id, amount, user=usr)
 
 		if("build_item")
 			var/design_id = params["design_id"]
 			var/amount = text2num(params["amount"])
-			add_to_queue(build_queue, design_id, amount)
+			add_to_queue(build_queue, design_id, amount, user=usr)
 
 		if("begin_process")
 			begin_process()
@@ -287,9 +287,11 @@
 			continue
 		update_static_data(M)
 
-/obj/machinery/autolathe/proc/add_to_queue(queue_list, design_id, amount, repeat=null)
+/obj/machinery/autolathe/proc/add_to_queue(queue_list, design_id, amount, repeat=null, user=null)
 	if(queue_list["[design_id]"])
 		queue_list["[design_id]"]["amount"] += amount
+		if(user)
+			queue_list["[design_id]"]["users"] |= WEAKREF(user)
 		if(queue_list["[design_id]"]["amount"] <= 0)
 			queue_list -= "[design_id]"
 		return
@@ -311,10 +313,15 @@
 				if(!used_material)
 					return //Didn't pick any material, so you can't build shit either.
 
+	var/list/users = list()
+	if(user)
+		users |= WEAKREF(user)
+
 	queue_list["[design_id]"] = list(
 		"amount" = amount,
 		"repeating" = repeat,
 		"build_mat" = used_material,
+		"users" = users,
 	)
 
 /obj/machinery/autolathe/proc/get_release_turf()
@@ -479,7 +486,12 @@
 		//Create item and restart
 		process_completion_world_tick = world.time + time
 		total_build_time = time
-		addtimer(CALLBACK(src, .proc/make_item, power, materials_used, custom_materials, multiplier, coeff, is_stack), time)
+		var/list/datum/weakref/users
+		if(from_build_queue)
+			users = build_queue[requested_design_id]["users"]
+		else
+			users = item_queue[requested_design_id]["users"]
+		addtimer(CALLBACK(src, .proc/make_item, power, materials_used, custom_materials, multiplier, coeff, is_stack, users), time)
 		addtimer(CALLBACK(src, .proc/restart_process), time + 5)
 	else
 		say("Insufficient materials, operation will proceed when sufficient materials are available.")
@@ -493,7 +505,7 @@
 		return
 	begin_process()
 
-/obj/machinery/autolathe/proc/make_item(power, list/materials_used, list/picked_materials, multiplier, coeff, is_stack, mob/user)
+/obj/machinery/autolathe/proc/make_item(power, list/materials_used, list/picked_materials, multiplier, coeff, is_stack, list/datum/weakref/users)
 	if(QDELETED(src))
 		return
 	//Stops the queue
@@ -518,7 +530,9 @@
 				for(var/x in picked_materials)
 					var/datum/material/M = x
 					if(!istype(M, /datum/material/glass) && !istype(M, /datum/material/iron))
-						user.client.give_award(/datum/award/achievement/misc/getting_an_upgrade, user)
+						for(var/datum/weakref/user_ref in users)
+							var/mob/user = user_ref.resolve()
+							user?.client?.give_award(/datum/award/achievement/misc/getting_an_upgrade, user)
 
 
 	being_built = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The autolathe tries to award an award to the person using it when they print something using custom materials other than glass and iron. With the bee tgui autolathe, the user printing was no longer passed to the `make_item` proc.

Because of this, it seems to break down completely after printing such items.

This PR tracks all users that have requested an item to be printed and tries to award the achievement to every user that requested the specific design.

~~The PR is completely untested, besides running `dreamchecker`, because it's too damn late for me to be testing this right now. Don't merge without testing yourself, otherwise wait for me to get around to it, which is annoying because it involves switching BYOND versions.~~

The PR has been tested, after a fix should be good to merge.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Autolathe no longer breaks when printing items with unusual custom materials
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
