### PR TITLE
Add's Grenade launcher to the cargo console

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -571,6 +571,13 @@
 	crate_name = "ion rifle crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 	dangerous = TRUE
+	
+/datum/supply_pack/security/armory/grenade_launcher
+	name = "Grenade Launcher Crate"
+	desc = "A handy grenade launcher that will fire any sort of grenade you come across."
+	cost = 6500
+	small_item = FALSE
+	contains = list(/obj/item/gun/grenadelauncher)	
 
 /datum/supply_pack/security/armory/mindshield
 	name = "Mindshield Implants Crate"


### PR DESCRIPTION

## About The Pull Request
Added the grenade launcher that shoots chem grenades to the cargo console purchasable for 6500 credits

## Why It's Good For The Game
the station lacks one since we dont have an armory roundstart plus i dont really see a reason why not


## Changelog
